### PR TITLE
first pass at creating MultiThreadedClientServiceCache

### DIFF
--- a/core/src/main/java/com/bazaarvoice/ostrich/ThreadSafeServiceFactory.java
+++ b/core/src/main/java/com/bazaarvoice/ostrich/ThreadSafeServiceFactory.java
@@ -1,0 +1,4 @@
+package com.bazaarvoice.ostrich;
+
+public interface ThreadSafeServiceFactory<S> extends ServiceFactory<S> {
+}

--- a/core/src/main/java/com/bazaarvoice/ostrich/pool/MultiThreadedClientServiceCache.java
+++ b/core/src/main/java/com/bazaarvoice/ostrich/pool/MultiThreadedClientServiceCache.java
@@ -1,0 +1,450 @@
+package com.bazaarvoice.ostrich.pool;
+
+import com.bazaarvoice.ostrich.ServiceEndPoint;
+import com.bazaarvoice.ostrich.ServiceFactory;
+import com.bazaarvoice.ostrich.ThreadSafeServiceFactory;
+import com.bazaarvoice.ostrich.metrics.Metrics;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.RemovalCause;
+import com.google.common.cache.RemovalListener;
+import com.google.common.cache.RemovalNotification;
+import com.google.common.collect.Maps;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * A cache for "heavy weight" client instances, i.e. ones that are already thread safe.
+ * Therefore as a {@code ServiceCache} we can just map Endpoints to single instances of those
+ * "heavy weight" clients.
+ * 
+ * This applies to third party client libraries for connecting to generic or specialized
+ * services, i.e. HttpClient, JestClient, etc.
+ * 
+ * This cache does no actual caching. It lies to {@code ServicePool}, the consumer of ServiceCache,
+ * mimics the behavior of cache, and returns singleton instance of service maintained in
+ * a map, keyed with{@code ServiceEndPoint}
+ *
+ * @param <S> the Service type
+ */
+public class MultiThreadedClientServiceCache<S> implements ServiceCache<S> {
+    private static final Logger LOG = LoggerFactory.getLogger(MultiThreadedClientServiceCache.class);
+    /**
+     * Note on volatile:
+     * The instancesPerEndpoint map holds the singleton service handles per every unique
+     * key constructed from endpoint name and id. It is HashMap, chosen for its performance.
+     * However since updates can throw ConcurrentModificationException when updated by two
+     * threads simultaneously, copy-on-write is chosen to counteract that.
+     *
+     * Which raises another problem, where the object might have different states in (cpu) cache
+     * and (main) memory as a result of assignment from one thread and simultaneous read from
+     * another thread, resulting in discrepancy of retrieved data across threads. Therefore to
+     * counteract that it is declared as volatile, such that it will never be cached and must
+     * be read from and written back to the (main) memory on any and every access. There is a
+     * performance penalty associated with volatile, but that is negligible.
+     *
+     * Read more at: http://jeremymanson.blogspot.com/2008/05/double-checked-locking.html
+     *
+     * In practice this ensures that the assignment operation is atomic across threads which is
+     * much desirable for copy-on-write operation.
+     *
+     * The same argument goes to all other volatile variables
+     *
+     * Note on evictedList:
+     * The evicted list is basically a guava cache with a configurable ttl to gracefully clean
+     * up evicted service handles. Note that, this does not prevent a consumer thread to request
+     * an evicted endpoint after another thread marked it as evicted. This is left up to the
+     * consumer to not request an evicted endpoint. This does however guarantees that an endpoint
+     * marked for eviction will eventually be marked for deletion, and will be deleted. This delay
+     * allows existing threads who already have them checked out, finish up their task gracefully
+     * before destroying the endpoint service handle.
+     *
+     * Note on deletedList:
+     * From evicted list an endpoint goes to deleted list, or re-registering an endpoint moves
+     * the old instance handle to deleted list. This list has a static wait time of 30 second
+     * before the cleanup thread destroys the associated service handle.
+     */
+    private volatile Map<ServiceEndPoint, ServiceHandle<S>> _instancesPerEndpoint;
+    private volatile boolean _isClosed;
+
+    // for tracking when was the last time a client was created for an end point
+    private final Map<ServiceEndPoint, Long> _mostRecentClientCreationTimePerEndpoint;
+    private final Cache<ServiceEndPoint, ServiceHandle<S>> _evictedList;
+
+    // for maintaining the list of items marked for deletion
+    private final AtomicLong _deletionCounter;
+    private final Cache<Long, ServiceHandle<S>> _toBeDeletedList;
+
+    // timers to report register and evict events
+    private final Timer _registerTimer, _evictionTimer;
+    private final Metrics.InstanceMetrics _metrics;
+
+    // factory to deal with service handles
+    private final ServiceFactory<S> _serviceFactory;
+
+    // default time in seconds before the scheduled job cleans up the deleted items
+    private static final int DEFAULT_CLEANUP_DELAY = 30;
+
+    // time to wait before registering the same endpoint already created by other thread
+    private static final long DUP_REGISTRATION_WINDOW = 1000l; // 1 second
+
+    // scheduled cleanup job executor
+    private final Future<?> _cleanupFuture;
+    private static final ScheduledExecutorService CLEANUP_EXECUTOR =
+            Executors.newScheduledThreadPool(1, new ThreadFactoryBuilder()
+                    .setNameFormat("ServiceCache-CleanupThread-%d")
+                    .setDaemon(true)
+                    .build());
+
+
+    /**
+     * Builds a MultiThreadedClientServiceCache. Used by the builder, used defaults
+     * for {@code ScheduledExecutorService} and {@code cleanupDelay}
+     *
+     * @param serviceFactory            the service factory for creating service handles
+     * @param evictionDurationInSeconds the eviction duration (in seconds) to keep evicted handles around
+     * @param metricRegistry            the metric registry for reporting metrics
+     */
+    MultiThreadedClientServiceCache(ThreadSafeServiceFactory<S> serviceFactory, int evictionDurationInSeconds,
+                                    MetricRegistry metricRegistry) {
+        this(serviceFactory, CLEANUP_EXECUTOR, evictionDurationInSeconds, DEFAULT_CLEANUP_DELAY, metricRegistry);
+    }
+
+    /**
+     * Builds a MultiThreadedClientServiceCache.
+     *
+     * @param serviceFactory            the service factory for creating service handles
+     * @param executor                  the executor for creating the eviction list (cache) cleanup thread
+     * @param evictionDurationInSeconds the eviction duration (in seconds) to keep evicted handles around
+     * @param metricRegistry            the metric registry for reporting metrics
+     */
+    MultiThreadedClientServiceCache(ThreadSafeServiceFactory<S> serviceFactory, ScheduledExecutorService executor,
+                                    int evictionDurationInSeconds, int cleanUpDelayInSeconds, MetricRegistry metricRegistry) {
+        checkNotNull(serviceFactory);
+        checkNotNull(metricRegistry);
+        checkArgument(evictionDurationInSeconds >= 0);
+        checkArgument(cleanUpDelayInSeconds >= 0);
+
+        // This is COW because we are dealing with extremely large number of reads and very few writes
+        // also, this is read from checkout(), therefore we're trying to keep it lightweight
+        _instancesPerEndpoint = Maps.newHashMap();
+        // reads and writes are fairly equal and this is not read from checkout()
+        _mostRecentClientCreationTimePerEndpoint = Maps.newConcurrentMap();
+        _serviceFactory = serviceFactory;
+        _isClosed = false;
+
+        _evictedList = CacheBuilder.newBuilder().expireAfterWrite(evictionDurationInSeconds, TimeUnit.SECONDS)
+                .removalListener(createEvictionListener()).build();
+
+        _toBeDeletedList = CacheBuilder.newBuilder().expireAfterWrite(cleanUpDelayInSeconds, TimeUnit.SECONDS)
+                .removalListener(createDeletionListener()).build();
+
+        _cleanupFuture = executor.scheduleAtFixedRate(createCleanupRunnableTask(), DEFAULT_CLEANUP_DELAY, DEFAULT_CLEANUP_DELAY, TimeUnit.SECONDS);
+
+        _deletionCounter = new AtomicLong();
+        _metrics = Metrics.forInstance(metricRegistry, this, serviceFactory.getServiceName());
+        _registerTimer = _metrics.timer("register-time");
+        _evictionTimer = _metrics.timer("eviction-time");
+    }
+
+    /**
+     * Mimics the behavior of a cache check in, actually a NOOP
+     * 
+     * Since there are no multiple service handle and their associated versions
+     * to maintain, check in in free!
+     *
+     * @param handle The service handle that is being checked in.
+     * @throws NullPointerException if the handle is null
+     */
+    @Override
+    public void checkIn(ServiceHandle<S> handle) throws Exception {
+        checkNotNull(handle);
+    }
+
+    /**
+     * check out the instance of service handle.
+     * if its not registered, registers it synchronously and then returns the newly created handle
+     *
+     * @param endPoint The end point to retrieve the instance of service handle
+     * @return the service handle
+     * @throws IllegalStateException if the cache is closed
+     * @throws NullPointerException if endpoint is null
+     */
+    @Override
+    public ServiceHandle<S> checkOut(ServiceEndPoint endPoint) throws Exception {
+        checkNotNull(endPoint);
+        if (_isClosed) {
+            throw new IllegalStateException("cache is closed");
+        }
+        ServiceHandle<S> instanceHandle = _instancesPerEndpoint.get(endPoint);
+        if (instanceHandle == null) {
+            return doRegister(endPoint);
+        }
+        return instanceHandle;
+    }
+
+    /**
+     * Private registration method that is used by checkout() and register()
+     *
+     * @param endPoint the end point
+     * @return the service handle
+     */
+    private synchronized ServiceHandle<S> doRegister(ServiceEndPoint endPoint) {
+        checkNotNull(endPoint);
+
+        ServiceHandle<S> oldServiceHandle = _instancesPerEndpoint.get(endPoint);
+        if(oldServiceHandle == null || isEndPointOld(endPoint)) {
+            S service = _serviceFactory.create(endPoint);
+            ServiceHandle<S> newServiceHandle = new ServiceHandle<>(service, endPoint);
+            _instancesPerEndpoint = cowAddToMap(endPoint, newServiceHandle);
+            _mostRecentClientCreationTimePerEndpoint.put(endPoint, System.currentTimeMillis());
+            if (oldServiceHandle != null) {
+                putInDeletedList(oldServiceHandle);
+            }
+            return newServiceHandle;
+        }
+        else {
+            return oldServiceHandle;
+        }
+    }
+
+    /**
+     * This registers an endpoint in the cache if its not already registered
+     * This also removes the same from evicted list if existed and puts it in
+     * deleted list
+     *
+     * @param endPoint to register on the cache
+     */
+    @Override
+    public synchronized void register(ServiceEndPoint endPoint) {
+        checkNotNull(endPoint);
+        Timer.Context context = _registerTimer.time();
+        doRegister(endPoint);
+        ServiceHandle<S> evictedServiceHandle = _evictedList.getIfPresent(endPoint);
+        if(evictedServiceHandle != null) {
+            _evictedList.invalidate(endPoint);
+        }
+        context.stop();
+    }
+
+    /**
+     * This evicts an endpoint, subsequent calls to checkout on the endPoint will
+     * fail with {@code EndPointEvictedException} unless that endPoint is registered again
+     *
+     * @param endPoint to evict from the cache
+     */
+    @Override
+    public synchronized void evict(ServiceEndPoint endPoint) {
+        checkNotNull(endPoint);
+        Timer.Context context = _evictionTimer.time();
+        if(_instancesPerEndpoint.containsKey(endPoint)) {
+            ServiceHandle<S> serviceHandle = _instancesPerEndpoint.get(endPoint);
+            _evictedList.put(endPoint, serviceHandle);
+        }
+        context.stop();
+    }
+
+    /**
+     * Mark the cache as closed to prevent further checkouts, clean up resource
+     */
+    @Override
+    public synchronized void close() {
+        _isClosed = true;
+        for (ServiceHandle<S> serviceHandle : _instancesPerEndpoint.values()) {
+            putInDeletedList(serviceHandle);
+        }
+        _instancesPerEndpoint = Maps.newHashMap();
+        _mostRecentClientCreationTimePerEndpoint.clear();
+        _evictedList.invalidateAll();
+        _toBeDeletedList.invalidateAll();
+        _cleanupFuture.cancel(false);
+        _metrics.close();
+    }
+
+    /**
+     * As these clients are multi threaded single instance, there's always one available
+     *
+     * @param endPoint to find idle instance count
+     * @return 1 if endPoint is registered, 0 otherwise
+     */
+    @Override
+    public int getNumIdleInstances(ServiceEndPoint endPoint) {
+        checkNotNull(endPoint);
+        return _instancesPerEndpoint.containsKey(endPoint) ? 1 : 0;
+    }
+
+    /**
+     * This does not track if an instance is actively being used, however given its
+     * singleton nature but it is safe to assume it is always being used
+     *
+     * @param endPoint to find active instance count
+     * @return 1 if endPoint is registered, 0 otherwise
+     */
+    @Override
+    public int getNumActiveInstances(ServiceEndPoint endPoint) {
+        checkNotNull(endPoint);
+        return _instancesPerEndpoint.containsKey(endPoint) ? 1 : 0;
+    }
+
+    /**
+     * Destroys a service handle gracefully, swallows any exception
+     *
+     * We only remove from the timestamp map if the timestamp is old and
+     * therefore has no value  aka
+     * (System.currentTimeMillis() > lastUpdated + DUP_REGISTRATION_WINDOW)
+     *
+     * @param serviceHandle the service handle
+     */
+    private void destroyService(ServiceHandle<S> serviceHandle) {
+        if (serviceHandle != null) {
+            try {
+                if (_mostRecentClientCreationTimePerEndpoint.containsKey(serviceHandle.getEndPoint())
+                        && isEndPointOld(serviceHandle.getEndPoint())) {
+                    _mostRecentClientCreationTimePerEndpoint.remove(serviceHandle.getEndPoint());
+                }
+                _serviceFactory.destroy(serviceHandle.getEndPoint(), serviceHandle.getService());
+            }
+            catch (Exception e) {
+                LOG.error("Service handle destroy failed for end point: " + serviceHandle.getEndPoint(), e);
+            }
+        }
+    }
+
+    /**
+     * Put in deleted items queue
+     *
+     * @param handle the handle to add the the queue of deleted items for the end point
+     */
+    private void putInDeletedList(ServiceHandle<S> handle) {
+        _toBeDeletedList.put(_deletionCounter.getAndIncrement(), handle);
+    }
+
+    /**
+     * Creates a removal listener for toBeEvictedList
+     *
+     * On receiving a removal notification, this will explicitly destroy the handle if the
+     * notification was {@code EXPIRED}
+     * Otherwise, it'll move the handle to the toBeDeleted list for future removal
+     *
+     * @return the removal listener
+     */
+    private RemovalListener<ServiceEndPoint, ServiceHandle<S>> createEvictionListener() {
+        return new RemovalListener<ServiceEndPoint, ServiceHandle<S>>() {
+            @Override
+            public void onRemoval(RemovalNotification<ServiceEndPoint, ServiceHandle<S>> notification) {
+                ServiceEndPoint endPoint = notification.getKey();
+                ServiceHandle<S> handle = notification.getValue();
+                // we modify the instancesPerEndPoint on EXPIRED only,
+                // but we always just mark the handle for deletion
+                if(RemovalCause.EXPIRED.equals(notification.getCause())) {
+                    // don't need double check lock, this will be single threaded
+                    synchronized (this) {
+                        _instancesPerEndpoint = cowRemoveFromMap(endPoint);
+                    }
+                }
+                putInDeletedList(handle);
+            }
+        };
+    }
+
+    /**
+     * Creates a removal listener for toBeDeletedList
+     *
+     * @return the removal listener
+     */
+    private RemovalListener<Long, ServiceHandle<S>> createDeletionListener() {
+        return new RemovalListener<Long, ServiceHandle<S>>() {
+            @Override
+            public void onRemoval(RemovalNotification<Long, ServiceHandle<S>> notification) {
+                ServiceHandle<S> handle = notification.getValue();
+                destroyService(handle);
+            }
+        };
+    }
+
+    /**
+     * Creates a runnable object used for scheduled cleanup
+     *
+     * Try to cleanup, error should never happen, but log just in case.
+     * Swallow exception so thread doesn't die.
+     *
+     * @return the runnable object
+     */
+    private Runnable createCleanupRunnableTask() {
+        return new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    _evictedList.cleanUp();
+                } catch (Exception e) {
+                    LOG.error("eviction list cleanup failed", e);
+                }
+                try {
+                    _toBeDeletedList.cleanUp();
+                } catch (Exception e) {
+                    LOG.error("deletion list cleanup failed", e);
+                }
+            }
+        };
+    }
+
+    /**
+     * Checks if a client for an end point is created before the DUP_REGISTRATION_WINDOW
+     *
+     * There are inherent race conditions from the zookeper discovery, and we
+     * do not want to create multiple clients for the same endpoint because of
+     * it. Hence we are checking the mostRecentClientCreationTimePerEndpoint
+     * map to see if it was created within the DUP_REGISTRATION_WINDOW or not
+     *
+     * @param endPoint the end point
+     * @return the boolean
+     */
+    private boolean isEndPointOld(ServiceEndPoint endPoint) {
+        Long lastUpdated = _mostRecentClientCreationTimePerEndpoint.get(endPoint);
+        // not having a timestamp ==> not old
+        // current time > timestamp + wait-window ==> old
+        return (lastUpdated != null && (System.currentTimeMillis() > lastUpdated + DUP_REGISTRATION_WINDOW));
+
+    }
+
+    /**
+     * Copy on write helper method to add a endPoint-handle pair to non-synchronized _instancesPerEndpoint map
+     *
+     * @param endPoint    the endPoint to put
+     * @param handle  the handle to put
+     * @return a new map with the requested add
+     */
+    private Map<ServiceEndPoint, ServiceHandle<S>> cowAddToMap(ServiceEndPoint endPoint, ServiceHandle<S> handle) {
+        checkNotNull(endPoint);
+        checkNotNull(handle);
+        Map<ServiceEndPoint, ServiceHandle<S>> sourceCopy = Maps.newHashMap(_instancesPerEndpoint);
+        sourceCopy.put(endPoint, handle);
+        return sourceCopy;
+    }
+
+    /**
+     * Copy on write helper method to remove endPoint from non-synchronized _instancesPerEndpoint map
+     *
+     * @param endPoint    the endPoint to remove
+     * @return a new map with the requested remove
+     */
+    private Map<ServiceEndPoint, ServiceHandle<S>> cowRemoveFromMap(ServiceEndPoint endPoint) {
+        checkNotNull(endPoint);
+        Map<ServiceEndPoint, ServiceHandle<S>> sourceCopy = Maps.newHashMap(_instancesPerEndpoint);
+        sourceCopy.remove(endPoint);
+        return sourceCopy;
+    }
+}

--- a/core/src/main/java/com/bazaarvoice/ostrich/pool/ServiceCache.java
+++ b/core/src/main/java/com/bazaarvoice/ostrich/pool/ServiceCache.java
@@ -1,280 +1,52 @@
 package com.bazaarvoice.ostrich.pool;
 
 import com.bazaarvoice.ostrich.ServiceEndPoint;
-import com.bazaarvoice.ostrich.ServiceFactory;
-import com.bazaarvoice.ostrich.exceptions.NoCachedInstancesAvailableException;
-import com.bazaarvoice.ostrich.metrics.Metrics;
-import com.codahale.metrics.MetricRegistry;
-import com.codahale.metrics.RatioGauge;
-import com.codahale.metrics.Timer;
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.MapMaker;
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import org.apache.commons.pool.BaseKeyedPoolableObjectFactory;
-import org.apache.commons.pool.impl.GenericKeyedObjectPool;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
-import java.util.Map;
-import java.util.NoSuchElementException;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
-/**
- * A cache for service instances. Useful if there's more than insignificant overhead in creating service connections
- * from a {@link ServiceEndPoint}.  Will spawn one thread (shared by all {@code ServiceCache}s) to handle evictions of
- */
-class ServiceCache<S> implements Closeable {
-    private static final Logger LOG = LoggerFactory.getLogger(ServiceCache.class);
-    private static final ScheduledExecutorService EVICTION_EXECUTOR = Executors.newScheduledThreadPool(1,
-            new ThreadFactoryBuilder()
-                    .setNameFormat("ServiceCache-EvictionThread-%d")
-                    .setDaemon(true)
-                    .build());
-
-    /** How often to try to evict old service instances. */
-    @VisibleForTesting
-    static final long EVICTION_DURATION_IN_SECONDS = 300;
-
-    private final GenericKeyedObjectPool<ServiceEndPoint, S> _pool;
-    private final AtomicLong _revisionNumber = new AtomicLong();
-    private final Map<ServiceEndPoint, Long> _invalidRevisions = new MapMaker().weakKeys().makeMap();
-    private final Map<ServiceHandle<S>, Long> _checkedOutRevisions = new MapMaker().makeMap();
-    private final Future<?> _evictionFuture;
-    private volatile boolean _isClosed = false;
-    private final Metrics.InstanceMetrics _metrics;
-    private final Timer _loadTimer;
-    private final AtomicLong _requestCount = new AtomicLong();
-    private final AtomicLong _missCount = new AtomicLong();
-    private final AtomicLong _loadSuccessCount = new AtomicLong();
-    private final AtomicLong _loadFailureCount = new AtomicLong();
+public interface ServiceCache<S> extends Closeable {
 
     /**
-     * Builds a basic service cache.
+     * Check out the instance of service handle.
      *
-     * @param policy         The configuration for this cache.
-     * @param serviceFactory The factory to fall back to on cache misses.
-     * @param metrics        The metric registry.
+     * @param endPoint The end point to retrieve the instance of service handle
+     * @return the service handle
      */
-    ServiceCache(ServiceCachingPolicy policy, ServiceFactory<S> serviceFactory, MetricRegistry metrics) {
-        this(policy, serviceFactory, EVICTION_EXECUTOR, metrics);
-    }
+    public ServiceHandle<S> checkOut(ServiceEndPoint endPoint) throws Exception;
 
     /**
-     * Builds a basic service cache.
+     * Mimics the behavior of a cache check in,
      *
-     * @param policy         The configuration for this cache.
-     * @param serviceFactory The factory to fall back to on cache misses.
-     * @param executor       The executor to use for checking for idle instances to evict.
+     * @param handle The service handle that is being checked in
      */
-    @VisibleForTesting
-    ServiceCache(ServiceCachingPolicy policy, ServiceFactory<S> serviceFactory, ScheduledExecutorService executor,
-                 MetricRegistry metrics) {
-        checkNotNull(policy);
-        checkNotNull(serviceFactory);
-        checkNotNull(executor);
-
-        String serviceName = serviceFactory.getServiceName();
-        _metrics = Metrics.forInstance(metrics, this, serviceName);
-        _loadTimer = _metrics.timer("load-time");
-
-        _metrics.gauge("cache-hit-ratio", new RatioGauge() {
-            @Override
-            protected Ratio getRatio() {
-                return Ratio.of(_requestCount.get() - _missCount.get(), _requestCount.get());
-            }
-        });
-
-        _metrics.gauge("cache-miss-ratio", new RatioGauge() {
-            @Override
-            protected Ratio getRatio() {
-                return Ratio.of(_missCount.get(), _requestCount.get());
-            }
-        });
-
-        _metrics.gauge("load-success-ratio", new RatioGauge() {
-            @Override
-            protected Ratio getRatio() {
-                return Ratio.of(_loadSuccessCount.get(), _loadSuccessCount.get() + _loadFailureCount.get());
-            }
-        });
-        _metrics.gauge("load-failure-ratio", new RatioGauge() {
-            @Override
-            protected Ratio getRatio() {
-                return Ratio.of(_loadFailureCount.get(), _loadSuccessCount.get() + _loadFailureCount.get());
-            }
-        });
-
-        GenericKeyedObjectPool.Config poolConfig = new GenericKeyedObjectPool.Config();
-
-        // Global configuration
-        poolConfig.maxTotal = policy.getMaxNumServiceInstances();
-        poolConfig.numTestsPerEvictionRun = policy.getMaxNumServiceInstances();
-        poolConfig.minEvictableIdleTimeMillis = policy.getMaxServiceInstanceIdleTime(TimeUnit.MILLISECONDS);
-
-        switch (policy.getCacheExhaustionAction()) {
-            case FAIL:
-                poolConfig.whenExhaustedAction = GenericKeyedObjectPool.WHEN_EXHAUSTED_FAIL;
-                break;
-            case GROW:
-                poolConfig.whenExhaustedAction = GenericKeyedObjectPool.WHEN_EXHAUSTED_GROW;
-                break;
-            case WAIT:
-                poolConfig.whenExhaustedAction = GenericKeyedObjectPool.WHEN_EXHAUSTED_BLOCK;
-                break;
-        }
-
-        // Per end point configuration
-        poolConfig.maxActive = policy.getMaxNumServiceInstancesPerEndPoint();
-        poolConfig.maxIdle = policy.getMaxNumServiceInstancesPerEndPoint();
-
-        // Make sure all instances in the pool are checked for staleness during eviction runs.
-        poolConfig.numTestsPerEvictionRun = policy.getMaxNumServiceInstances();
-
-        _pool = new GenericKeyedObjectPool<>(new PoolServiceFactory<>(serviceFactory), poolConfig);
-
-        // Don't schedule eviction if not caching or not expiring stale instances.
-        _evictionFuture = (policy.getMaxNumServiceInstances() != 0)
-                || (policy.getMaxNumServiceInstancesPerEndPoint() != 0)
-                || (policy.getMaxServiceInstanceIdleTime(TimeUnit.MILLISECONDS) > 0)
-                ? executor.scheduleAtFixedRate(new Runnable() {
-                      @Override
-                      public void run() {
-                          try {
-                              _pool.evict();
-                          } catch (Exception e) {
-                              // Should never happen, but log just in case. Swallow exception so thread doesn't die.
-                              LOG.error("ServiceCache eviction run failed.", e);
-                          }
-                      }
-                  }, EVICTION_DURATION_IN_SECONDS, EVICTION_DURATION_IN_SECONDS, TimeUnit.SECONDS)
-                : null;
-    }
-
-    @VisibleForTesting
-    GenericKeyedObjectPool<ServiceEndPoint, S> getPool() {
-        return _pool;
-    }
+    public void checkIn(ServiceHandle<S> handle) throws Exception;
 
     /**
-     * Retrieves a cached service instance for an end point that is not currently checked out.  If no idle cached
-     * instance is available and the cache is not full, a new one will be created, added to the cache, and then checked
-     * out.  Once the checked out instance is no longer in use, it should be returned by calling {@link #checkIn}.
-     *
-     * @param endPoint The end point to retrieve a cached service instance for.
-     * @return A service handle that contains a cached service instance for the requested end point.
-     * @throws NoCachedInstancesAvailableException If the cache has reached total maximum capacity, or maximum capacity
-     *         for the requested end point, and no connections that aren't already checked out are available.
+     * @param endPoint to find idle instance count
+     * @return number of registered service handles for the given endpoint
      */
-    public ServiceHandle<S> checkOut(ServiceEndPoint endPoint) throws Exception {
-        checkNotNull(endPoint);
-        _requestCount.incrementAndGet();
-
-        try {
-            long revision = _revisionNumber.incrementAndGet();
-            S service = _pool.borrowObject(endPoint);
-            ServiceHandle<S> handle = new ServiceHandle<>(service, endPoint);
-
-            // Remember the revision that we've checked this service out on in case we need to invalidate it later
-            _checkedOutRevisions.put(handle, revision);
-
-            return handle;
-        } catch (NoSuchElementException e) {
-            _missCount.incrementAndGet();
-
-            // This will happen if there are no available connections and there is no room for a new one,
-            // or if a newly created connection is not valid.
-            throw new NoCachedInstancesAvailableException();
-        }
-    }
+    public int getNumIdleInstances(ServiceEndPoint endPoint);
 
     /**
-     * Returns a service instance for an end point to the cache so that it may be used by other users.
-     *
-     * @param handle The service handle that is being checked in.
-     * @throws Exception Never.
+     * @param endPoint to find active instance count
+     * @return number of active service handles for a given endpoint
      */
-    public void checkIn(ServiceHandle<S> handle) throws Exception {
-        checkNotNull(handle);
+    public int getNumActiveInstances(ServiceEndPoint endPoint);
 
-        S service = handle.getService();
-        ServiceEndPoint endPoint = handle.getEndPoint();
-
-        // Figure out if we should check this revision in.  If it was created before the last known invalid revision
-        // for this particular end point, or the cache is closed, then we shouldn't check it in.
-        Long invalidRevision = _invalidRevisions.get(endPoint);
-        Long serviceRevision = _checkedOutRevisions.remove(handle);
-
-        if (_isClosed || (invalidRevision != null && serviceRevision < invalidRevision)) {
-            _pool.invalidateObject(endPoint, service);
-        } else {
-            _pool.returnObject(endPoint, service);
-        }
-    }
-
-    public int getNumIdleInstances(ServiceEndPoint endPoint) {
-        checkNotNull(endPoint);
-        return _pool.getNumIdle(endPoint);
-    }
-
-    public int getNumActiveInstances(ServiceEndPoint endPoint) {
-        checkNotNull(endPoint);
-        return _pool.getNumActive(endPoint);
-    }
-
+    /**
+     * closes the cache
+     */
     @Override
-    public void close() {
-        _isClosed = true;
+    public void close();
 
-        if (_evictionFuture != null) {
-            _evictionFuture.cancel(false);
-        }
+    /**
+     * @param endPoint to register on the cache
+     */
+    public void register(ServiceEndPoint endPoint);
 
-        _pool.clear();
-        _metrics.close();
-    }
+    /**
+     * @param endPoint to evict from the cache
+     */
+    public void evict(ServiceEndPoint endPoint);
 
-    public void evict(ServiceEndPoint endPoint) {
-        checkNotNull(endPoint);
-
-        // Mark all service instances created prior to now as invalid so that we don't inadvertently check them back in
-        _invalidRevisions.put(endPoint, _revisionNumber.incrementAndGet());
-        _pool.clear(endPoint);
-    }
-
-    private class PoolServiceFactory<S> extends BaseKeyedPoolableObjectFactory<ServiceEndPoint, S> {
-        private final ServiceFactory<S> _serviceFactory;
-
-        public PoolServiceFactory(ServiceFactory<S> serviceFactory) {
-            _serviceFactory = serviceFactory;
-        }
-
-        @Override
-        public S makeObject(final ServiceEndPoint endPoint) throws Exception {
-            _missCount.incrementAndGet();
-
-            Timer.Context timer = _loadTimer.time();
-            try {
-                S service = _serviceFactory.create(endPoint);
-                _loadSuccessCount.incrementAndGet();
-                return service;
-            } catch (Exception e) {
-                _loadFailureCount.incrementAndGet();
-                throw e;
-            } finally {
-                timer.stop();
-            }
-        }
-
-        @Override
-        public void destroyObject(ServiceEndPoint endPoint, S service) throws Exception {
-            _serviceFactory.destroy(endPoint, service);
-        }
-    }
 }

--- a/core/src/main/java/com/bazaarvoice/ostrich/pool/ServiceCacheBuilder.java
+++ b/core/src/main/java/com/bazaarvoice/ostrich/pool/ServiceCacheBuilder.java
@@ -1,0 +1,48 @@
+package com.bazaarvoice.ostrich.pool;
+
+import com.bazaarvoice.ostrich.ServiceFactory;
+import com.bazaarvoice.ostrich.ThreadSafeServiceFactory;
+import com.codahale.metrics.MetricRegistry;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class ServiceCacheBuilder<S> {
+
+    private ServiceCachingPolicy _cachingPolicy;
+    private ServiceFactory<S> _serviceFactory;
+    private MetricRegistry _metricRegistry;
+
+    public ServiceCacheBuilder<S> withCachingPolicy(ServiceCachingPolicy cachingPolicy) {
+        _cachingPolicy = cachingPolicy;
+        return this;
+    }
+
+    public ServiceCacheBuilder<S> withServiceFactory(ServiceFactory<S> serviceFactory) {
+        _serviceFactory = serviceFactory;
+        return this;
+    }
+
+    public ServiceCacheBuilder<S> withMetricRegistry(MetricRegistry metricRegistry) {
+        _metricRegistry = metricRegistry;
+        return this;
+    }
+
+    public ServiceCache<S> build() {
+        checkNotNull(_cachingPolicy);
+        if (_cachingPolicy.useMultiThreadedClientPolicy()) {
+            checkArgument(_cachingPolicy.evictionTTLForMultiThreadedClientPolicy() >= 0);
+            checkNotNull(_serviceFactory);
+            if(!(_serviceFactory instanceof ThreadSafeServiceFactory)) {
+                throw new IllegalArgumentException("Please implement ThreadSafeServiceFactory to construct MultiThreadedClientServiceCache");
+            }
+            return new MultiThreadedClientServiceCache<>((ThreadSafeServiceFactory<S>) _serviceFactory,
+                    _cachingPolicy.evictionTTLForMultiThreadedClientPolicy(), _metricRegistry);
+        }
+        else {
+            checkNotNull(_serviceFactory);
+            checkNotNull(_metricRegistry);
+            return new SingleThreadedClientServiceCache<>(_cachingPolicy, _serviceFactory, _metricRegistry);
+        }
+    }
+}

--- a/core/src/main/java/com/bazaarvoice/ostrich/pool/ServiceCachingPolicy.java
+++ b/core/src/main/java/com/bazaarvoice/ostrich/pool/ServiceCachingPolicy.java
@@ -51,4 +51,20 @@ public interface ServiceCachingPolicy {
         /** Wait until an instance is returned to the cache when at the limit of the number of allowed instances. */
         WAIT
     }
+
+    /**
+     * This defaults to false, i.e. the default Policy to support a ServiceCache of single threaded clients.
+     *
+     * If this is set to true, all other params are ignored, and their getters throws unsupported operation exception
+     *
+     * @return true is policy is intended for multi threaded clients
+     */
+    boolean useMultiThreadedClientPolicy();
+
+    /**
+     * This makes the evicted items ttl configurable
+     *
+     * @return amount of time in seconds to keep an evicted item around
+     */
+    int evictionTTLForMultiThreadedClientPolicy();
 }

--- a/core/src/main/java/com/bazaarvoice/ostrich/pool/ServiceCachingPolicyBuilder.java
+++ b/core/src/main/java/com/bazaarvoice/ostrich/pool/ServiceCachingPolicyBuilder.java
@@ -3,15 +3,71 @@ package com.bazaarvoice.ostrich.pool;
 import java.util.concurrent.TimeUnit;
 
 import static com.bazaarvoice.ostrich.pool.ServiceCachingPolicy.ExhaustionAction;
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
 public class ServiceCachingPolicyBuilder {
+    public static final int EVICTION_DURATION_SECONDS = 300;
     public static final ServiceCachingPolicy NO_CACHING = new ServiceCachingPolicyBuilder()
             .withMaxNumServiceInstances(0)
             .withMaxNumServiceInstancesPerEndPoint(0)
             .withCacheExhaustionAction(ExhaustionAction.GROW)
             .build();
+
+    /**
+     * Default multi thread clients policy with eviction duration of 300 seconds
+     */
+    public static final ServiceCachingPolicy DEFAULT_MULTI_THREAD_CLIENTS_POLICY = newMultiThreadedClientPolicy(EVICTION_DURATION_SECONDS);
+
+    /**
+     * Creates a ServiceCachingPolice configured for multi threaded client strategy,
+     * the {@code MultiThreadedClientServiceCache}
+     * <p/>
+     * This policy returns true for useMultiThreadedClientPolicy() but throws
+     * {@code UnsupportedOperationException} for everything else
+     *
+     * A zero eviction duration calls for immediate eviction of a bad handle,
+     * otherwise it waits for specified seconds before automatically removing
+     * the handle
+     *
+     * @param evictionTTLDuration the eviction tTL duration in seconds
+     * @return ServiceCachingPolicy configured to build a {@code MultiThreadClientServiceCache}
+     */
+    public static ServiceCachingPolicy newMultiThreadedClientPolicy(final int evictionTTLDuration) {
+        checkArgument(evictionTTLDuration > 0);
+        return new ServiceCachingPolicy() {
+            @Override
+            public int getMaxNumServiceInstances() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public int getMaxNumServiceInstancesPerEndPoint() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public long getMaxServiceInstanceIdleTime(TimeUnit unit) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public ExhaustionAction getCacheExhaustionAction() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public boolean useMultiThreadedClientPolicy() {
+                return true;
+            }
+
+            @Override
+            public int evictionTTLForMultiThreadedClientPolicy() {
+                return evictionTTLDuration;
+            }
+        };
+    }
 
     private int _maxNumServiceInstances = -1;
     private int _maxNumServiceInstancesPerEndPoint = -1;
@@ -110,6 +166,16 @@ public class ServiceCachingPolicyBuilder {
             @Override
             public ExhaustionAction getCacheExhaustionAction() {
                 return cacheExhaustionAction;
+            }
+
+            @Override
+            public boolean useMultiThreadedClientPolicy() {
+                return false;
+            }
+
+            @Override
+            public int evictionTTLForMultiThreadedClientPolicy() {
+                throw new UnsupportedOperationException();
             }
         };
     }

--- a/core/src/main/java/com/bazaarvoice/ostrich/pool/ServiceCachingPolicyBuilder.java
+++ b/core/src/main/java/com/bazaarvoice/ostrich/pool/ServiceCachingPolicyBuilder.java
@@ -35,7 +35,7 @@ public class ServiceCachingPolicyBuilder {
      * @return ServiceCachingPolicy configured to build a {@code MultiThreadClientServiceCache}
      */
     public static ServiceCachingPolicy newMultiThreadedClientPolicy(final int evictionTTLDuration) {
-        checkArgument(evictionTTLDuration > 0);
+        checkArgument(evictionTTLDuration >= 0);
         return new ServiceCachingPolicy() {
             @Override
             public int getMaxNumServiceInstances() {

--- a/core/src/main/java/com/bazaarvoice/ostrich/pool/SingleThreadedClientServiceCache.java
+++ b/core/src/main/java/com/bazaarvoice/ostrich/pool/SingleThreadedClientServiceCache.java
@@ -1,0 +1,302 @@
+package com.bazaarvoice.ostrich.pool;
+
+import com.bazaarvoice.ostrich.ServiceEndPoint;
+import com.bazaarvoice.ostrich.ServiceFactory;
+import com.bazaarvoice.ostrich.exceptions.NoCachedInstancesAvailableException;
+import com.bazaarvoice.ostrich.metrics.Metrics;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.RatioGauge;
+import com.codahale.metrics.Timer;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.MapMaker;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.apache.commons.pool.BaseKeyedPoolableObjectFactory;
+import org.apache.commons.pool.impl.GenericKeyedObjectPool;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * A cache for service instances. Useful if there's more than insignificant overhead in creating service connections
+ * from a {@link ServiceEndPoint}.  Will spawn one thread (shared by all {@code ServiceCache}s) to handle evictions of
+ */
+class SingleThreadedClientServiceCache<S> implements ServiceCache<S> {
+    private static final Logger LOG = LoggerFactory.getLogger(SingleThreadedClientServiceCache.class);
+    private static final ScheduledExecutorService EVICTION_EXECUTOR = Executors.newScheduledThreadPool(1,
+            new ThreadFactoryBuilder()
+                    .setNameFormat("ServiceCache-EvictionThread-%d")
+                    .setDaemon(true)
+                    .build());
+
+    /** How often to try to evict old service instances. */
+    @VisibleForTesting
+    static final long EVICTION_DURATION_IN_SECONDS = 300;
+
+    private final GenericKeyedObjectPool<ServiceEndPoint, S> _pool;
+    private final AtomicLong _revisionNumber = new AtomicLong();
+    private final Map<ServiceEndPoint, Long> _invalidRevisions = new MapMaker().weakKeys().makeMap();
+    private final Map<ServiceHandle<S>, Long> _checkedOutRevisions = new MapMaker().makeMap();
+    private final Future<?> _evictionFuture;
+    private volatile boolean _isClosed = false;
+    private final Metrics.InstanceMetrics _metrics;
+    private final Timer _loadTimer;
+    private final AtomicLong _requestCount = new AtomicLong();
+    private final AtomicLong _missCount = new AtomicLong();
+    private final AtomicLong _loadSuccessCount = new AtomicLong();
+    private final AtomicLong _loadFailureCount = new AtomicLong();
+
+    /**
+     * Builds a basic service cache.
+     *
+     * @param policy         The configuration for this cache.
+     * @param serviceFactory The factory to fall back to on cache misses.
+     * @param metrics        The metric registry.
+     */
+    SingleThreadedClientServiceCache(ServiceCachingPolicy policy, ServiceFactory<S> serviceFactory, MetricRegistry metrics) {
+        this(policy, serviceFactory, EVICTION_EXECUTOR, metrics);
+    }
+
+    /**
+     * Builds a basic service cache.
+     *
+     * @param policy         The configuration for this cache.
+     * @param serviceFactory The factory to fall back to on cache misses.
+     * @param executor       The executor to use for checking for idle instances to evict.
+     */
+    @VisibleForTesting
+    SingleThreadedClientServiceCache(ServiceCachingPolicy policy, ServiceFactory<S> serviceFactory, ScheduledExecutorService executor,
+                                     MetricRegistry metrics) {
+        checkNotNull(policy);
+        checkNotNull(serviceFactory);
+        checkNotNull(executor);
+
+        String serviceName = serviceFactory.getServiceName();
+        _metrics = Metrics.forInstance(metrics, this, serviceName);
+        _loadTimer = _metrics.timer("load-time");
+
+        _metrics.gauge("cache-hit-ratio", new RatioGauge() {
+            @Override
+            protected Ratio getRatio() {
+                return Ratio.of(_requestCount.get() - _missCount.get(), _requestCount.get());
+            }
+        });
+
+        _metrics.gauge("cache-miss-ratio", new RatioGauge() {
+            @Override
+            protected Ratio getRatio() {
+                return Ratio.of(_missCount.get(), _requestCount.get());
+            }
+        });
+
+        _metrics.gauge("load-success-ratio", new RatioGauge() {
+            @Override
+            protected Ratio getRatio() {
+                return Ratio.of(_loadSuccessCount.get(), _loadSuccessCount.get() + _loadFailureCount.get());
+            }
+        });
+        _metrics.gauge("load-failure-ratio", new RatioGauge() {
+            @Override
+            protected Ratio getRatio() {
+                return Ratio.of(_loadFailureCount.get(), _loadSuccessCount.get() + _loadFailureCount.get());
+            }
+        });
+
+        GenericKeyedObjectPool.Config poolConfig = new GenericKeyedObjectPool.Config();
+
+        // Global configuration
+        poolConfig.maxTotal = policy.getMaxNumServiceInstances();
+        poolConfig.numTestsPerEvictionRun = policy.getMaxNumServiceInstances();
+        poolConfig.minEvictableIdleTimeMillis = policy.getMaxServiceInstanceIdleTime(TimeUnit.MILLISECONDS);
+
+        switch (policy.getCacheExhaustionAction()) {
+            case FAIL:
+                poolConfig.whenExhaustedAction = GenericKeyedObjectPool.WHEN_EXHAUSTED_FAIL;
+                break;
+            case GROW:
+                poolConfig.whenExhaustedAction = GenericKeyedObjectPool.WHEN_EXHAUSTED_GROW;
+                break;
+            case WAIT:
+                poolConfig.whenExhaustedAction = GenericKeyedObjectPool.WHEN_EXHAUSTED_BLOCK;
+                break;
+        }
+
+        // Per end point configuration
+        poolConfig.maxActive = policy.getMaxNumServiceInstancesPerEndPoint();
+        poolConfig.maxIdle = policy.getMaxNumServiceInstancesPerEndPoint();
+
+        // Make sure all instances in the pool are checked for staleness during eviction runs.
+        poolConfig.numTestsPerEvictionRun = policy.getMaxNumServiceInstances();
+
+        _pool = new GenericKeyedObjectPool<>(new PoolServiceFactory<>(serviceFactory), poolConfig);
+
+        // Don't schedule eviction if not caching or not expiring stale instances.
+        _evictionFuture = (policy.getMaxNumServiceInstances() != 0)
+                || (policy.getMaxNumServiceInstancesPerEndPoint() != 0)
+                || (policy.getMaxServiceInstanceIdleTime(TimeUnit.MILLISECONDS) > 0)
+                ? executor.scheduleAtFixedRate(new Runnable() {
+                      @Override
+                      public void run() {
+                          try {
+                              _pool.evict();
+                          } catch (Exception e) {
+                              // Should never happen, but log just in case. Swallow exception so thread doesn't die.
+                              LOG.error("ServiceCache eviction run failed.", e);
+                          }
+                      }
+                  }, EVICTION_DURATION_IN_SECONDS, EVICTION_DURATION_IN_SECONDS, TimeUnit.SECONDS)
+                : null;
+    }
+
+    @VisibleForTesting
+    GenericKeyedObjectPool<ServiceEndPoint, S> getPool() {
+        return _pool;
+    }
+
+    /**
+     * Retrieves a cached service instance for an end point that is not currently checked out.  If no idle cached
+     * instance is available and the cache is not full, a new one will be created, added to the cache, and then checked
+     * out.  Once the checked out instance is no longer in use, it should be returned by calling {@link #checkIn}.
+     *
+     * @param endPoint The end point to retrieve a cached service instance for.
+     * @return A service handle that contains a cached service instance for the requested end point.
+     * @throws NoCachedInstancesAvailableException If the cache has reached total maximum capacity, or maximum capacity
+     *         for the requested end point, and no connections that aren't already checked out are available.
+     */
+    public ServiceHandle<S> checkOut(ServiceEndPoint endPoint) throws Exception {
+        checkNotNull(endPoint);
+        _requestCount.incrementAndGet();
+
+        try {
+            long revision = _revisionNumber.incrementAndGet();
+            S service = _pool.borrowObject(endPoint);
+            ServiceHandle<S> handle = new ServiceHandle<>(service, endPoint);
+
+            // Remember the revision that we've checked this service out on in case we need to invalidate it later
+            _checkedOutRevisions.put(handle, revision);
+
+            return handle;
+        } catch (NoSuchElementException e) {
+            _missCount.incrementAndGet();
+
+            // This will happen if there are no available connections and there is no room for a new one,
+            // or if a newly created connection is not valid.
+            throw new NoCachedInstancesAvailableException();
+        }
+    }
+
+    /**
+     * Returns a service instance for an end point to the cache so that it may be used by other users.
+     *
+     * @param handle The service handle that is being checked in.
+     * @throws Exception Never.
+     */
+    public void checkIn(ServiceHandle<S> handle) throws Exception {
+        checkNotNull(handle);
+
+        S service = handle.getService();
+        ServiceEndPoint endPoint = handle.getEndPoint();
+
+        // Figure out if we should check this revision in.  If it was created before the last known invalid revision
+        // for this particular end point, or the cache is closed, then we shouldn't check it in.
+        Long invalidRevision = _invalidRevisions.get(endPoint);
+        Long serviceRevision = _checkedOutRevisions.remove(handle);
+
+        if (_isClosed || (invalidRevision != null && serviceRevision < invalidRevision)) {
+            _pool.invalidateObject(endPoint, service);
+        } else {
+            _pool.returnObject(endPoint, service);
+        }
+    }
+
+    public int getNumIdleInstances(ServiceEndPoint endPoint) {
+        checkNotNull(endPoint);
+        return _pool.getNumIdle(endPoint);
+    }
+
+    public int getNumActiveInstances(ServiceEndPoint endPoint) {
+        checkNotNull(endPoint);
+        return _pool.getNumActive(endPoint);
+    }
+
+    @Override
+    public void close() {
+        _isClosed = true;
+
+        if (_evictionFuture != null) {
+            _evictionFuture.cancel(false);
+        }
+
+        try {
+            _pool.close();
+        }
+        catch(Exception e) {
+            LOG.error("Error closing pool", e);
+        }
+        _metrics.close();
+    }
+
+    /**
+     * As new end points gets added to the service pool, as part of initialization
+     * this method allows the pool to register that endpoint to the cache. Ideally
+     * this allows the cache to have a service handle ready for checkout before
+     * the first request comes in.
+     *
+     * This is particularly helpful for heavyweight clients that are expensive to create.
+     *
+     * @param endPoint to register on the cache
+     */
+    public void register(ServiceEndPoint endPoint) {
+        // NOOP
+        // Given that this implementation of ServiceCache was designed to create
+        // clients on the fly / lazily as needed, the register mechanic is not ideal
+        // for it, but this method and it's usage by the ServicePool is useful to
+        // the MultiThreadedClientServiceCache.
+    }
+
+    public void evict(ServiceEndPoint endPoint) {
+        checkNotNull(endPoint);
+
+        // Mark all service instances created prior to now as invalid so that we don't inadvertently check them back in
+        _invalidRevisions.put(endPoint, _revisionNumber.incrementAndGet());
+        _pool.clear(endPoint);
+    }
+
+    private class PoolServiceFactory<S> extends BaseKeyedPoolableObjectFactory<ServiceEndPoint, S> {
+        private final ServiceFactory<S> _serviceFactory;
+
+        public PoolServiceFactory(ServiceFactory<S> serviceFactory) {
+            _serviceFactory = serviceFactory;
+        }
+
+        @Override
+        public S makeObject(final ServiceEndPoint endPoint) throws Exception {
+            _missCount.incrementAndGet();
+
+            Timer.Context timer = _loadTimer.time();
+            try {
+                S service = _serviceFactory.create(endPoint);
+                _loadSuccessCount.incrementAndGet();
+                return service;
+            } catch (Exception e) {
+                _loadFailureCount.incrementAndGet();
+                throw e;
+            } finally {
+                timer.stop();
+            }
+        }
+
+        @Override
+        public void destroyObject(ServiceEndPoint endPoint, S service) throws Exception {
+            _serviceFactory.destroy(endPoint, service);
+        }
+    }
+}

--- a/core/src/test/java/com/bazaarvoice/ostrich/pool/AbstractServicePoolTestingHarness.java
+++ b/core/src/test/java/com/bazaarvoice/ostrich/pool/AbstractServicePoolTestingHarness.java
@@ -57,24 +57,30 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
-public class ServicePoolTest {
-    private static final ServiceEndPoint FOO_ENDPOINT = mock(ServiceEndPoint.class);
-    private static final ServiceEndPoint BAR_ENDPOINT = mock(ServiceEndPoint.class);
-    private static final ServiceEndPoint BAZ_ENDPOINT = mock(ServiceEndPoint.class);
-    private static final Service FOO_SERVICE = mock(Service.class);
-    private static final Service BAR_SERVICE = mock(Service.class);
-    private static final Service BAZ_SERVICE = mock(Service.class);
-    private static final RetryPolicy NEVER_RETRY = mock(RetryPolicy.class);
-    private static final ServiceCachingPolicy UNLIMITED_CACHING = new ServiceCachingPolicyBuilder().build();
+public abstract class AbstractServicePoolTestingHarness {
 
-    private Ticker _ticker;
-    private HostDiscovery _hostDiscovery;
-    private PartitionFilter _partitionFilter;
-    private LoadBalanceAlgorithm _loadBalanceAlgorithm;
-    private ServiceFactory<Service> _serviceFactory;
-    private ScheduledExecutorService _healthCheckExecutor;
-    private MetricRegistry _registry;
-    private ServicePool<Service> _pool;
+    protected static final ServiceEndPoint FOO_ENDPOINT = mock(ServiceEndPoint.class);
+    protected static final ServiceEndPoint BAR_ENDPOINT = mock(ServiceEndPoint.class);
+    protected static final ServiceEndPoint BAZ_ENDPOINT = mock(ServiceEndPoint.class);
+    protected static final Service FOO_SERVICE = mock(Service.class);
+    protected static final Service BAR_SERVICE = mock(Service.class);
+    protected static final Service BAZ_SERVICE = mock(Service.class);
+    protected static final RetryPolicy NEVER_RETRY = mock(RetryPolicy.class);
+
+    protected final ServiceCachingPolicy UNLIMITED_CACHING = getServiceCachingPolicy();
+
+    protected Ticker _ticker;
+    protected HostDiscovery _hostDiscovery;
+    protected PartitionFilter _partitionFilter;
+    protected LoadBalanceAlgorithm _loadBalanceAlgorithm;
+    protected ServiceFactory<Service> _serviceFactory;
+    protected ScheduledExecutorService _healthCheckExecutor;
+    protected MetricRegistry _registry;
+    protected ServicePool<Service> _pool;
+
+    protected abstract ServiceCachingPolicy getServiceCachingPolicy();
+    protected abstract ServiceFactory<Service> getServiceFactoryMock();
+
 
     @SuppressWarnings("unchecked")
     @Before
@@ -110,7 +116,7 @@ public class ServicePoolTest {
                     }
                 });
 
-        _serviceFactory = (ServiceFactory<Service>) mock(ServiceFactory.class);
+        _serviceFactory = getServiceFactoryMock();
         when(_serviceFactory.getServiceName()).thenReturn(Service.class.getSimpleName());
         when(_serviceFactory.create(FOO_ENDPOINT)).thenReturn(FOO_SERVICE);
         when(_serviceFactory.create(BAR_ENDPOINT)).thenReturn(BAR_SERVICE);
@@ -521,73 +527,6 @@ public class ServicePoolTest {
     }
 
     @Test
-    public void testStatsNumActiveInstancesDecrementsAfterExecute() {
-        // Make sure we only get FOO_ENDPOINT.
-        reset(_loadBalanceAlgorithm);
-        when(_loadBalanceAlgorithm.choose(Matchers.<Iterable<ServiceEndPoint>>any(), any(ServicePoolStatistics.class)))
-                .thenReturn(FOO_ENDPOINT);
-
-        final ServicePoolStatistics servicePoolStatistics = _pool.getServicePoolStatistics();
-
-        int numActiveDuringExecute = _pool.execute(NEVER_RETRY, new ServiceCallback<Service, Integer>() {
-            @Override
-            public Integer call(Service service) throws ServiceException {
-                return servicePoolStatistics.getNumActiveInstances(FOO_ENDPOINT);
-            }
-        });
-
-        int numActiveAfterExecute = servicePoolStatistics.getNumActiveInstances(FOO_ENDPOINT);
-
-        assertEquals(numActiveDuringExecute - 1, numActiveAfterExecute);
-    }
-
-    @Test
-    public void testStatsNumIdleCachedInstancesIncrementsAfterExecute() {
-        // Make sure we only get FOO_ENDPOINT.
-        reset(_loadBalanceAlgorithm);
-        when(_loadBalanceAlgorithm.choose(Matchers.<Iterable<ServiceEndPoint>>any(), any(ServicePoolStatistics.class)))
-                .thenReturn(FOO_ENDPOINT);
-
-        final ServicePoolStatistics servicePoolStatistics = _pool.getServicePoolStatistics();
-
-        int numIdleDuringExecute = _pool.execute(NEVER_RETRY, new ServiceCallback<Service, Integer>() {
-            @Override
-            public Integer call(Service service) throws ServiceException {
-                return servicePoolStatistics.getNumIdleCachedInstances(FOO_ENDPOINT);
-            }
-        });
-
-        int numIdleAfterExecute = servicePoolStatistics.getNumIdleCachedInstances(FOO_ENDPOINT);
-
-        assertEquals(numIdleDuringExecute + 1, numIdleAfterExecute);
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test
-    public void testStatsNumIdleCachedInstancesDecrementsDuringExecute() {
-        // Make sure we only get FOO_ENDPOINT.
-        reset(_loadBalanceAlgorithm);
-        when(_loadBalanceAlgorithm.choose(Matchers.<Iterable<ServiceEndPoint>>any(), any(ServicePoolStatistics.class)))
-                .thenReturn(FOO_ENDPOINT);
-
-        // Prime the cache.
-        _pool.execute(NEVER_RETRY, mock(ServiceCallback.class));
-
-        final ServicePoolStatistics servicePoolStatistics = _pool.getServicePoolStatistics();
-
-        int numIdleInitially = servicePoolStatistics.getNumIdleCachedInstances(FOO_ENDPOINT);
-
-        int numIdleDuringExecute = _pool.execute(NEVER_RETRY, new ServiceCallback<Service, Integer>() {
-            @Override
-            public Integer call(Service service) throws ServiceException {
-                return servicePoolStatistics.getNumIdleCachedInstances(FOO_ENDPOINT);
-            }
-        });
-
-        assertEquals(numIdleInitially - 1, numIdleDuringExecute);
-    }
-
-    @Test
     public void testCheckForHealthyEndPointWhenEmpty() {
         when(_hostDiscovery.getHosts()).thenReturn(Collections.<ServiceEndPoint>emptySet());
 
@@ -960,6 +899,6 @@ public class ServicePoolTest {
     }
 
     // A dummy interface for testing...
-    private static interface Service {
+    protected static interface Service {
     }
 }

--- a/core/src/test/java/com/bazaarvoice/ostrich/pool/MultiThreadedClientServiceCacheTest.java
+++ b/core/src/test/java/com/bazaarvoice/ostrich/pool/MultiThreadedClientServiceCacheTest.java
@@ -1,0 +1,249 @@
+package com.bazaarvoice.ostrich.pool;
+
+import com.bazaarvoice.ostrich.ServiceEndPoint;
+import com.bazaarvoice.ostrich.ThreadSafeServiceFactory;
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.collect.Lists;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.util.List;
+import java.util.concurrent.Executors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class MultiThreadedClientServiceCacheTest {
+    private ServiceEndPoint _endPoint;
+    private ThreadSafeServiceFactory<Service> _factory;
+    private List<MultiThreadedClientServiceCache<?>> _caches = Lists.newArrayList();
+    private MetricRegistry _metricRegistry = new MetricRegistry();
+
+    @SuppressWarnings ("unchecked")
+    @Before
+    public void setup() {
+        _factory = mock(ThreadSafeServiceFactory.class);
+        when(_factory.getServiceName()).thenReturn(Service.class.getSimpleName());
+        when(_factory.create(any(ServiceEndPoint.class))).thenAnswer(new Answer<Service>() {
+            @Override
+            public Service answer(InvocationOnMock invocation)
+                    throws Throwable {
+                return mock(Service.class);
+            }
+        });
+        _endPoint = newEndPoint("id", "name");
+    }
+
+    @After
+    public void teardown() {
+        for (MultiThreadedClientServiceCache<?> cache : _caches) {
+            cache.close();
+        }
+    }
+
+    @Test (expected = NullPointerException.class)
+    public void testCheckOutFromNullEndPoint()
+            throws Exception {
+        newCache().checkOut(null);
+    }
+
+    @Test (expected = NullPointerException.class)
+    public void testCheckInNullHandle()
+            throws Exception {
+        newCache().checkIn(null);
+    }
+
+    @Test (expected = NullPointerException.class)
+    public void testCheckInToNullEndPoint()
+            throws Exception {
+        Service service = mock(Service.class);
+        ServiceHandle<Service> handle = new ServiceHandle<>(service, null);
+        newCache().checkIn(handle);
+    }
+
+    @Test (expected = NullPointerException.class)
+    public void testCheckInNullServiceInstance()
+            throws Exception {
+        ServiceHandle<Service> handle = new ServiceHandle<>(null, _endPoint);
+        newCache().checkIn(handle);
+    }
+
+    @Test (expected = NullPointerException.class)
+    public void testEvictNullEndPoint() {
+        newCache().evict(null);
+    }
+
+    @Test
+    public void testFactoryExceptionIsPropagated() {
+        NullPointerException exception = mock(NullPointerException.class);
+        when(_factory.create(any(ServiceEndPoint.class))).thenThrow(exception);
+
+        try {
+            newCache().register(_endPoint);
+            fail();
+        } catch (Exception caught) {
+            assertSame(exception, caught);
+        }
+    }
+
+    @Test
+    public void testServiceInstancesAreIsReused()
+            throws Exception {
+        Service service = mock(Service.class);
+        when(_factory.create(any(ServiceEndPoint.class))).thenReturn(service);
+
+        MultiThreadedClientServiceCache<Service> cache = newCache();
+        ServiceHandle<Service> handle1 = cache.checkOut(_endPoint);
+        ServiceHandle<Service> handle2 = cache.checkOut(_endPoint);
+        ServiceHandle<Service> handle3 = cache.checkOut(_endPoint);
+        ServiceHandle<Service> handle4 = cache.checkOut(_endPoint);
+
+
+        assertSame(service, handle1.getService());
+        assertSame(service, handle2.getService());
+        assertSame(service, handle3.getService());
+        assertSame(service, handle4.getService());
+
+        assertEquals(1, cache.getNumActiveInstances(_endPoint));
+        assertEquals(1, cache.getNumIdleInstances(_endPoint));
+    }
+
+    @Test
+    public void testEvictedEndPointDestroyedManualEviction()
+            throws Exception {
+        MultiThreadedClientServiceCache<Service> cache = newCache(0);
+        ServiceHandle<Service> handle = cache.checkOut(_endPoint);
+        cache.checkIn(handle);
+        cache.evict(_endPoint);
+
+        verify(_factory).destroy(_endPoint, handle.getService());
+    }
+
+    @Test
+    public void testEvictedEndPointWhileServiceInstanceCheckedOut()
+            throws Exception {
+        Service validService = mock(Service.class);
+        ServiceEndPoint validEndPoint = newEndPoint("valid", "name");
+        when(_factory.create(validEndPoint)).thenReturn(validService);
+
+        Service invalidService = mock(Service.class);
+        ServiceEndPoint invalidEndPoint = newEndPoint("invalid", "name");
+        when(_factory.create(invalidEndPoint)).thenReturn(invalidService);
+
+        MultiThreadedClientServiceCache<Service> cache = newCache(0);
+        cache.register(invalidEndPoint);
+        cache.register(validEndPoint);
+
+        ServiceHandle<Service> invalidHandle = cache.checkOut(invalidEndPoint);
+        ServiceHandle<Service> validHandle = cache.checkOut(validEndPoint);
+
+        cache.evict(invalidEndPoint);
+
+        cache.checkIn(invalidHandle);
+        cache.checkIn(validHandle);
+
+        verify(_factory, never()).destroy(validEndPoint, validService);
+        verify(_factory, times(1)).destroy(invalidEndPoint, invalidService);
+    }
+
+    @Test
+    public void testEvictedEndPointWhileDuplicateServiceInstancesCheckedOut()
+            throws Exception {
+        Service service = mock(Service.class);
+        when(_factory.create(any(ServiceEndPoint.class))).thenReturn(service);
+
+        MultiThreadedClientServiceCache<Service> cache = newCache(0);
+
+        ServiceHandle<Service> handle1 = cache.checkOut(_endPoint);
+        ServiceHandle<Service> handle2 = cache.checkOut(_endPoint);
+
+        cache.evict(_endPoint);
+
+        cache.checkIn(handle1);
+        cache.checkIn(handle2);
+
+        assertSame(service, handle1.getService());
+        assertSame(service, handle2.getService());
+        verify(_factory, times(1)).destroy(_endPoint, service);
+    }
+
+    @Test (expected = NullPointerException.class)
+    public void testNumIdleNullEndPoint() {
+        MultiThreadedClientServiceCache<Service> cache = newCache();
+        cache.getNumIdleInstances(null);
+    }
+
+    @Test (expected = NullPointerException.class)
+    public void testNumActiveNullEndPoint() {
+        MultiThreadedClientServiceCache<Service> cache = newCache();
+        cache.getNumActiveInstances(null);
+    }
+
+    @Test
+    public void testNumActiveInstances()
+            throws Exception {
+        MultiThreadedClientServiceCache<Service> cache = newCache();
+        cache.register(_endPoint);
+        assertEquals(1, cache.getNumActiveInstances(_endPoint));
+        assertEquals(0, cache.getNumActiveInstances(newEndPoint("new", "endPoint")));
+    }
+
+    @Test
+    public void testNumIdleInstances()
+            throws Exception {
+        MultiThreadedClientServiceCache<Service> cache = newCache();
+        cache.register(_endPoint);
+        assertEquals(1, cache.getNumIdleInstances(_endPoint));
+        assertEquals(0, cache.getNumActiveInstances(newEndPoint("new", "endPoint")));
+    }
+
+    @Test
+    public void testCloseDestroysCachedInstances()
+            throws Exception {
+        MultiThreadedClientServiceCache<Service> cache = newCache();
+        ServiceHandle<Service> handle = cache.checkOut(_endPoint);
+        cache.checkIn(handle);
+        cache.close();
+
+        verify(_factory).destroy(_endPoint, handle.getService());
+    }
+
+
+    @Test
+    public void testMultipleClose() {
+        MultiThreadedClientServiceCache<Service> cache = newCache();
+        cache.close();
+        cache.close();
+    }
+
+    private MultiThreadedClientServiceCache<Service> newCache() {
+        return newCache(1);
+    }
+
+    private MultiThreadedClientServiceCache<Service> newCache(int ttl) {
+        MultiThreadedClientServiceCache<Service> cache = new MultiThreadedClientServiceCache<>(_factory, Executors.newSingleThreadScheduledExecutor(), ttl, ttl, _metricRegistry);
+        _caches.add(cache);
+        return cache;
+    }
+
+    private ServiceEndPoint newEndPoint(String id, String name) {
+        ServiceEndPoint endPoint = mock(ServiceEndPoint.class);
+        when(endPoint.getId()).thenReturn(id);
+        when(endPoint.getServiceName()).thenReturn(name);
+        when(endPoint.getPayload()).thenReturn("");
+        return endPoint;
+    }
+
+    public static interface Service {
+    }
+}

--- a/core/src/test/java/com/bazaarvoice/ostrich/pool/PoolWithMultiThreadedCacheTest.java
+++ b/core/src/test/java/com/bazaarvoice/ostrich/pool/PoolWithMultiThreadedCacheTest.java
@@ -1,0 +1,23 @@
+package com.bazaarvoice.ostrich.pool;
+
+import com.bazaarvoice.ostrich.ServiceFactory;
+import com.bazaarvoice.ostrich.ThreadSafeServiceFactory;
+
+import static org.mockito.Mockito.mock;
+
+public class PoolWithMultiThreadedCacheTest extends AbstractServicePoolTestingHarness {
+    @Override
+    protected ServiceCachingPolicy getServiceCachingPolicy() {
+        // eviction delay is set to zero to invalidate an evicted instance immediately.
+        // this allows us to validate the call to ServiceFactory#destroy()
+        return ServiceCachingPolicyBuilder.newMultiThreadedClientPolicy(0);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected ServiceFactory<Service> getServiceFactoryMock() {
+        // Multi threaded service cache requires the service factory to
+        // implement ThreadSafeServiceFactory (which extends ServiceFactory)
+        return (ServiceFactory<Service>) mock(ThreadSafeServiceFactory.class);
+    }
+}

--- a/core/src/test/java/com/bazaarvoice/ostrich/pool/PoolWithSingleThreadedCacheTest.java
+++ b/core/src/test/java/com/bazaarvoice/ostrich/pool/PoolWithSingleThreadedCacheTest.java
@@ -1,0 +1,99 @@
+package com.bazaarvoice.ostrich.pool;
+
+import com.bazaarvoice.ostrich.ServiceCallback;
+import com.bazaarvoice.ostrich.ServiceEndPoint;
+import com.bazaarvoice.ostrich.ServiceFactory;
+import com.bazaarvoice.ostrich.ServicePoolStatistics;
+import com.bazaarvoice.ostrich.exceptions.ServiceException;
+import org.junit.Test;
+import org.mockito.Matchers;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+public class PoolWithSingleThreadedCacheTest extends AbstractServicePoolTestingHarness {
+    @Override
+    protected ServiceCachingPolicy getServiceCachingPolicy() {
+        return new ServiceCachingPolicyBuilder().build();
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected ServiceFactory<AbstractServicePoolTestingHarness.Service> getServiceFactoryMock() {
+        return (ServiceFactory<Service>) mock(ServiceFactory.class);
+    }
+
+    @Test
+    public void testStatsNumIdleCachedInstancesIncrementsAfterExecute() {
+        // Make sure we only get FOO_ENDPOINT.
+        reset(_loadBalanceAlgorithm);
+        when(_loadBalanceAlgorithm.choose(Matchers.<Iterable<ServiceEndPoint>>any(), any(ServicePoolStatistics.class)))
+                .thenReturn(FOO_ENDPOINT);
+
+        final ServicePoolStatistics servicePoolStatistics = _pool.getServicePoolStatistics();
+
+        int numIdleDuringExecute = _pool.execute(NEVER_RETRY, new ServiceCallback<Service, Integer>() {
+            @Override
+            public Integer call(Service service)
+                    throws ServiceException {
+                return servicePoolStatistics.getNumIdleCachedInstances(FOO_ENDPOINT);
+            }
+        });
+
+        int numIdleAfterExecute = servicePoolStatistics.getNumIdleCachedInstances(FOO_ENDPOINT);
+
+        assertEquals(numIdleDuringExecute + 1, numIdleAfterExecute);
+    }
+
+    @Test
+    public void testStatsNumActiveInstancesDecrementsAfterExecute() {
+        // Make sure we only get FOO_ENDPOINT.
+        reset(_loadBalanceAlgorithm);
+        when(_loadBalanceAlgorithm.choose(Matchers.<Iterable<ServiceEndPoint>>any(), any(ServicePoolStatistics.class)))
+                .thenReturn(FOO_ENDPOINT);
+
+        final ServicePoolStatistics servicePoolStatistics = _pool.getServicePoolStatistics();
+
+        int numActiveDuringExecute = _pool.execute(NEVER_RETRY, new ServiceCallback<Service, Integer>() {
+            @Override
+            public Integer call(Service service)
+                    throws ServiceException {
+                return servicePoolStatistics.getNumActiveInstances(FOO_ENDPOINT);
+            }
+        });
+
+        int numActiveAfterExecute = servicePoolStatistics.getNumActiveInstances(FOO_ENDPOINT);
+
+        assertEquals(numActiveDuringExecute - 1, numActiveAfterExecute);
+    }
+
+    @SuppressWarnings ("unchecked")
+    @Test
+    public void testStatsNumIdleCachedInstancesDecrementsDuringExecute() {
+        // Make sure we only get FOO_ENDPOINT.
+        reset(_loadBalanceAlgorithm);
+        when(_loadBalanceAlgorithm.choose(Matchers.<Iterable<ServiceEndPoint>>any(), any(ServicePoolStatistics.class)))
+                .thenReturn(FOO_ENDPOINT);
+
+        // Prime the cache.
+        _pool.execute(NEVER_RETRY, mock(ServiceCallback.class));
+
+        final ServicePoolStatistics servicePoolStatistics = _pool.getServicePoolStatistics();
+
+        int numIdleInitially = servicePoolStatistics.getNumIdleCachedInstances(FOO_ENDPOINT);
+
+        int numIdleDuringExecute = _pool.execute(NEVER_RETRY, new ServiceCallback<Service, Integer>() {
+            @Override
+            public Integer call(Service service)
+                    throws ServiceException {
+                return servicePoolStatistics.getNumIdleCachedInstances(FOO_ENDPOINT);
+            }
+        });
+
+        assertEquals(numIdleInitially - 1, numIdleDuringExecute);
+    }
+
+}

--- a/core/src/test/java/com/bazaarvoice/ostrich/pool/ServiceCachingPolicyBuilderTest.java
+++ b/core/src/test/java/com/bazaarvoice/ostrich/pool/ServiceCachingPolicyBuilderTest.java
@@ -14,6 +14,20 @@ public class ServiceCachingPolicyBuilderTest {
 
         assertEquals(ServiceCachingPolicy.ExhaustionAction.GROW, builder.build().getCacheExhaustionAction());
     }
+
+    @Test
+    public void testUseMultiThreadedClientPolicy() {
+        ServiceCachingPolicy cachingPolicy = ServiceCachingPolicyBuilder.DEFAULT_MULTI_THREAD_CLIENTS_POLICY;
+
+        assertEquals(true, cachingPolicy.useMultiThreadedClientPolicy());
+    }
+
+    @Test
+    public void testDefaultMultiThreadedClientPolicy() {
+        ServiceCachingPolicyBuilder builder = new ServiceCachingPolicyBuilder();
+
+        assertEquals(false, builder.build().useMultiThreadedClientPolicy());
+    }
     
     @Test
     public void testMaxNumServiceInstancesSet() {
@@ -61,5 +75,29 @@ public class ServiceCachingPolicyBuilderTest {
     public void testInvalidMaxServiceInstanceIdleTime() {
         ServiceCachingPolicyBuilder builder = new ServiceCachingPolicyBuilder();
         builder.withMaxServiceInstanceIdleTime(0, TimeUnit.MILLISECONDS);
+    }
+
+    @Test (expected = UnsupportedOperationException.class)
+    public void testUseMultiThreadedClientPolicyWithMaxNumServiceInstancesPerEndPoint() {
+        ServiceCachingPolicy cachingPolicy = ServiceCachingPolicyBuilder.DEFAULT_MULTI_THREAD_CLIENTS_POLICY;
+        assertEquals(1, cachingPolicy.getMaxNumServiceInstancesPerEndPoint());
+    }
+
+    @Test (expected = UnsupportedOperationException.class)
+    public void testUseMultiThreadedClientPolicyWithMaxServiceInstanceIdleTime() {
+        ServiceCachingPolicy cachingPolicy = ServiceCachingPolicyBuilder.DEFAULT_MULTI_THREAD_CLIENTS_POLICY;
+        assertEquals(1, cachingPolicy.getMaxServiceInstanceIdleTime(TimeUnit.SECONDS));
+    }
+
+    @Test (expected = UnsupportedOperationException.class)
+    public void testUseMultiThreadedClientPolicyWithMaxNumServiceInstances() {
+        ServiceCachingPolicy cachingPolicy = ServiceCachingPolicyBuilder.DEFAULT_MULTI_THREAD_CLIENTS_POLICY;
+        assertEquals(1, cachingPolicy.getMaxNumServiceInstances());
+    }
+
+    @Test (expected = UnsupportedOperationException.class)
+    public void testUseMultiThreadedClientPolicyWithCacheExhaustionAction() {
+        ServiceCachingPolicy cachingPolicy = ServiceCachingPolicyBuilder.DEFAULT_MULTI_THREAD_CLIENTS_POLICY;
+        assertEquals(ServiceCachingPolicy.ExhaustionAction.GROW, cachingPolicy.getCacheExhaustionAction());
     }
 }

--- a/core/src/test/java/com/bazaarvoice/ostrich/pool/ServicePoolTest.java
+++ b/core/src/test/java/com/bazaarvoice/ostrich/pool/ServicePoolTest.java
@@ -21,7 +21,6 @@ import com.google.common.base.Ticker;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
-import com.google.common.util.concurrent.Futures;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -55,7 +54,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
@@ -212,7 +210,7 @@ public class ServicePoolTest {
     }
 
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings ({"unchecked", "rawType"})
     @Test
     public void testPartitionFilter() {
         reset(_partitionFilter);

--- a/core/src/test/java/com/bazaarvoice/ostrich/pool/SingleThreadedClientServiceCacheTest.java
+++ b/core/src/test/java/com/bazaarvoice/ostrich/pool/SingleThreadedClientServiceCacheTest.java
@@ -41,13 +41,13 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class ServiceCacheTest {
+public class SingleThreadedClientServiceCacheTest {
     private static final ServiceEndPoint END_POINT = mock(ServiceEndPoint.class);
 
     private ServiceFactory<Service> _factory;
     private ServiceCachingPolicy _cachingPolicy;
     private MetricRegistry _registry = new MetricRegistry();
-    private List<ServiceCache<?>> _caches = Lists.newArrayList();
+    private List<SingleThreadedClientServiceCache<?>> _caches = Lists.newArrayList();
 
     @SuppressWarnings("unchecked")
     @Before
@@ -70,7 +70,7 @@ public class ServiceCacheTest {
 
     @After
     public void teardown() {
-        for (ServiceCache<?> cache : _caches) {
+        for (SingleThreadedClientServiceCache<?> cache : _caches) {
             cache.close();
         }
     }
@@ -125,7 +125,7 @@ public class ServiceCacheTest {
         NullPointerException exception = mock(NullPointerException.class);
         when(_factory.create(any(ServiceEndPoint.class))).thenThrow(exception);
 
-        ServiceCache<Service> cache = newCache();
+        SingleThreadedClientServiceCache<Service> cache = newCache();
         try {
             cache.checkOut(END_POINT);
             fail();
@@ -136,7 +136,7 @@ public class ServiceCacheTest {
 
     @Test
     public void testServiceInstanceIsReused() throws Exception {
-        ServiceCache<Service> cache = newCache();
+        SingleThreadedClientServiceCache<Service> cache = newCache();
         ServiceHandle<Service> handle = cache.checkOut(END_POINT);
         cache.checkIn(handle);
 
@@ -148,7 +148,7 @@ public class ServiceCacheTest {
         // Allow 2 instances per end point
         when(_cachingPolicy.getMaxNumServiceInstancesPerEndPoint()).thenReturn(2);
 
-        ServiceCache<Service> cache = newCache();
+        SingleThreadedClientServiceCache<Service> cache = newCache();
         ServiceHandle<Service> handle = cache.checkOut(END_POINT);
         assertNotSame(handle.getService(), cache.checkOut(END_POINT).getService());
     }
@@ -159,7 +159,7 @@ public class ServiceCacheTest {
         when(_factory.create(any(ServiceEndPoint.class))).thenReturn(service);
         when(_cachingPolicy.getMaxNumServiceInstancesPerEndPoint()).thenReturn(-1);
 
-        ServiceCache<Service> cache = newCache();
+        SingleThreadedClientServiceCache<Service> cache = newCache();
         ServiceHandle<Service> handle1 = cache.checkOut(END_POINT);
         ServiceHandle<Service> handle2 = cache.checkOut(END_POINT);
 
@@ -177,7 +177,7 @@ public class ServiceCacheTest {
         Service service = mock(Service.class);
         when(_factory.create(any(ServiceEndPoint.class))).thenReturn(service);
 
-        ServiceCache<Service> cache = newCache();
+        SingleThreadedClientServiceCache<Service> cache = newCache();
 
         ServiceEndPoint endPoint1 = mock(ServiceEndPoint.class);
         ServiceEndPoint endPoint2 = mock(ServiceEndPoint.class);
@@ -206,7 +206,7 @@ public class ServiceCacheTest {
         // Make the cache only hold one instance total.
         when(_cachingPolicy.getMaxNumServiceInstances()).thenReturn(1);
 
-        ServiceCache<Service> cache = newCache();
+        SingleThreadedClientServiceCache<Service> cache = newCache();
         ServiceHandle<Service> handle = cache.checkOut(END_POINT);
 
         cache.checkIn(handle);
@@ -218,7 +218,7 @@ public class ServiceCacheTest {
 
     @Test
     public void testEvictedEndPointDestroyedManualEviction() throws Exception {
-        ServiceCache<Service> cache = newCache();
+        SingleThreadedClientServiceCache<Service> cache = newCache();
         ServiceHandle<Service> handle = cache.checkOut(END_POINT);
         cache.checkIn(handle);
         cache.evict(END_POINT);
@@ -228,7 +228,7 @@ public class ServiceCacheTest {
 
     @Test
     public void testEvictedEndPointHasServiceInstancesRemovedFromCache() throws Exception {
-        ServiceCache<Service> cache = newCache();
+        SingleThreadedClientServiceCache<Service> cache = newCache();
 
         ServiceHandle<Service> handle = cache.checkOut(END_POINT);
         cache.checkIn(handle);
@@ -239,7 +239,7 @@ public class ServiceCacheTest {
 
     @Test
     public void testEvictedEndPointWhileServiceInstanceCheckedOut() throws Exception {
-        ServiceCache<Service> cache = newCache();
+        SingleThreadedClientServiceCache<Service> cache = newCache();
 
         ServiceHandle<Service> handle = cache.checkOut(END_POINT);
         cache.evict(END_POINT);
@@ -254,7 +254,7 @@ public class ServiceCacheTest {
         when(_factory.create(any(ServiceEndPoint.class))).thenReturn(service);
         when(_cachingPolicy.getMaxNumServiceInstancesPerEndPoint()).thenReturn(-1);
 
-        ServiceCache<Service> cache = newCache();
+        SingleThreadedClientServiceCache<Service> cache = newCache();
 
         ServiceHandle<Service> handle1 = cache.checkOut(END_POINT);
         ServiceHandle<Service> handle2 = cache.checkOut(END_POINT);
@@ -273,7 +273,7 @@ public class ServiceCacheTest {
         when(_factory.create(any(ServiceEndPoint.class))).thenReturn(service);
         when(_cachingPolicy.getMaxNumServiceInstancesPerEndPoint()).thenReturn(-1);
 
-        ServiceCache<Service> cache = newCache();
+        SingleThreadedClientServiceCache<Service> cache = newCache();
         ServiceHandle<Service> handle1 = cache.checkOut(END_POINT);
 
         cache.evict(END_POINT);
@@ -293,7 +293,7 @@ public class ServiceCacheTest {
         Service service = mock(Service.class);
         when(_factory.create(any(ServiceEndPoint.class))).thenReturn(service);
 
-        ServiceCache<Service> cache = newCache();
+        SingleThreadedClientServiceCache<Service> cache = newCache();
 
         ServiceHandle<Service> handle = cache.checkOut(END_POINT);
         cache.evict(END_POINT);
@@ -310,7 +310,7 @@ public class ServiceCacheTest {
         Service service = mock(Service.class);
         when(_factory.create(any(ServiceEndPoint.class))).thenReturn(service);
 
-        ServiceCache<Service> cache = newCache();
+        SingleThreadedClientServiceCache<Service> cache = newCache();
 
         ServiceEndPoint invalidEndPoint = mock(ServiceEndPoint.class);
         ServiceEndPoint validEndPoint = mock(ServiceEndPoint.class);
@@ -331,7 +331,7 @@ public class ServiceCacheTest {
     public void testFailCacheExhaustionAction() throws Exception {
         when(_cachingPolicy.getCacheExhaustionAction()).thenReturn(ServiceCachingPolicy.ExhaustionAction.FAIL);
 
-        ServiceCache<Service> cache = newCache();
+        SingleThreadedClientServiceCache<Service> cache = newCache();
         cache.checkOut(END_POINT);
         cache.checkOut(END_POINT);
     }
@@ -340,7 +340,7 @@ public class ServiceCacheTest {
     public void testGrowCacheExhaustionAction() throws Exception {
         when(_cachingPolicy.getCacheExhaustionAction()).thenReturn(ServiceCachingPolicy.ExhaustionAction.GROW);
 
-        ServiceCache<Service> cache = newCache();
+        SingleThreadedClientServiceCache<Service> cache = newCache();
         cache.checkOut(END_POINT);
         cache.checkOut(END_POINT);
     }
@@ -350,7 +350,7 @@ public class ServiceCacheTest {
         when(_cachingPolicy.getMaxNumServiceInstancesPerEndPoint()).thenReturn(1);
         when(_cachingPolicy.getCacheExhaustionAction()).thenReturn(ServiceCachingPolicy.ExhaustionAction.GROW);
 
-        ServiceCache<Service> cache = newCache();
+        SingleThreadedClientServiceCache<Service> cache = newCache();
 
         // Grow the cache a bunch, remembering each service that was created...
         Set<ServiceHandle<Service>> seenHandles = Sets.newHashSet();
@@ -380,7 +380,7 @@ public class ServiceCacheTest {
         when(_cachingPolicy.getMaxNumServiceInstancesPerEndPoint()).thenReturn(1);
         when(_cachingPolicy.getCacheExhaustionAction()).thenReturn(ServiceCachingPolicy.ExhaustionAction.WAIT);
 
-        final ServiceCache<Service> cache = newCache();
+        final SingleThreadedClientServiceCache<Service> cache = newCache();
         ServiceHandle<Service> handle = cache.checkOut(END_POINT);
 
         // Run a 2nd check out operation in a background thread.  It should block because there is only one service
@@ -434,40 +434,40 @@ public class ServiceCacheTest {
         newCache(executor);
         verify(executor).scheduleAtFixedRate(
                 any(Runnable.class),
-                eq(ServiceCache.EVICTION_DURATION_IN_SECONDS),
-                eq(ServiceCache.EVICTION_DURATION_IN_SECONDS),
+                eq(SingleThreadedClientServiceCache.EVICTION_DURATION_IN_SECONDS),
+                eq(SingleThreadedClientServiceCache.EVICTION_DURATION_IN_SECONDS),
                 eq(TimeUnit.SECONDS));
     }
 
     @Test(expected = NullPointerException.class)
     public void testNumIdleNullEndPoint() {
-        ServiceCache<Service> cache = newCache();
+        SingleThreadedClientServiceCache<Service> cache = newCache();
         cache.getNumIdleInstances(null);
     }
 
     @Test(expected = NullPointerException.class)
     public void testNumActiveNullEndPoint() {
-        ServiceCache<Service> cache = newCache();
+        SingleThreadedClientServiceCache<Service> cache = newCache();
         cache.getNumActiveInstances(null);
     }
 
     @Test
     public void testNumIdleStartsAtZero() {
-        ServiceCache<Service> cache = newCache();
+        SingleThreadedClientServiceCache<Service> cache = newCache();
 
         assertEquals(0, cache.getNumIdleInstances(END_POINT));
     }
 
     @Test
     public void testNumActiveStartsAtZero() {
-        ServiceCache<Service> cache = newCache();
+        SingleThreadedClientServiceCache<Service> cache = newCache();
 
         assertEquals(0, cache.getNumActiveInstances(END_POINT));
     }
 
     @Test
     public void testNumActiveUpdatedOnCheckOut() throws Exception {
-        ServiceCache<Service> cache = newCache();
+        SingleThreadedClientServiceCache<Service> cache = newCache();
         cache.checkOut(END_POINT);
 
         assertEquals(1, cache.getNumActiveInstances(END_POINT));
@@ -475,7 +475,7 @@ public class ServiceCacheTest {
 
     @Test
     public void testNumIdleUpdatedOnCheckIn() throws Exception {
-        ServiceCache<Service> cache = newCache();
+        SingleThreadedClientServiceCache<Service> cache = newCache();
         cache.checkIn(cache.checkOut(END_POINT));
 
         assertEquals(1, cache.getNumIdleInstances(END_POINT));
@@ -483,7 +483,7 @@ public class ServiceCacheTest {
 
     @Test
     public void testActiveServiceNotCountedIdle() throws Exception {
-        ServiceCache<Service> cache = newCache();
+        SingleThreadedClientServiceCache<Service> cache = newCache();
         cache.checkOut(END_POINT);
 
         assertEquals(0, cache.getNumIdleInstances(END_POINT));
@@ -491,7 +491,7 @@ public class ServiceCacheTest {
 
     @Test
     public void testIdleServiceNotCountedActive() throws Exception {
-        ServiceCache<Service> cache = newCache();
+        SingleThreadedClientServiceCache<Service> cache = newCache();
         cache.checkIn(cache.checkOut(END_POINT));
 
         assertEquals(0, cache.getNumActiveInstances(END_POINT));
@@ -502,7 +502,7 @@ public class ServiceCacheTest {
         when(_cachingPolicy.getMaxNumServiceInstancesPerEndPoint()).thenReturn(1);
         when(_cachingPolicy.getCacheExhaustionAction()).thenReturn(ServiceCachingPolicy.ExhaustionAction.GROW);
 
-        ServiceCache<Service> cache = newCache();
+        SingleThreadedClientServiceCache<Service> cache = newCache();
         cache.checkOut(END_POINT);
         cache.checkOut(END_POINT);
 
@@ -511,7 +511,7 @@ public class ServiceCacheTest {
 
     @Test
     public void testCloseDestroysCachedInstances() throws Exception {
-        ServiceCache<Service> cache = newCache();
+        SingleThreadedClientServiceCache<Service> cache = newCache();
         ServiceHandle<Service> handle = cache.checkOut(END_POINT);
         cache.checkIn(handle);
         cache.close();
@@ -519,7 +519,7 @@ public class ServiceCacheTest {
         verify(_factory).destroy(END_POINT, handle.getService());
     }
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings ({"unchecked", "rawtypes"})
     @Test
     public void testCloseCancelsEvictionFuture() {
         when(_cachingPolicy.getMaxServiceInstanceIdleTime(any(TimeUnit.class))).thenReturn(10L);
@@ -531,7 +531,7 @@ public class ServiceCacheTest {
                 anyLong(),
                 any(TimeUnit.class))).thenReturn(future);
 
-        ServiceCache<Service> cache = newCache(executor);
+        SingleThreadedClientServiceCache<Service> cache = newCache(executor);
         cache.close();
 
         verify(future).cancel(anyBoolean());
@@ -539,19 +539,19 @@ public class ServiceCacheTest {
 
     @Test
     public void testMultipleClose() {
-        ServiceCache<Service> cache = newCache();
+        SingleThreadedClientServiceCache<Service> cache = newCache();
         cache.close();
         cache.close();
     }
 
-    private ServiceCache<Service> newCache() {
-        ServiceCache<Service> cache = new ServiceCache<>(_cachingPolicy, _factory, _registry);
+    private SingleThreadedClientServiceCache<Service> newCache() {
+        SingleThreadedClientServiceCache<Service> cache = new SingleThreadedClientServiceCache<>(_cachingPolicy, _factory, _registry);
         _caches.add(cache);
         return cache;
     }
 
-    private ServiceCache<Service> newCache(ScheduledExecutorService executor) {
-        ServiceCache<Service> cache = new ServiceCache<>(_cachingPolicy, _factory, executor, _registry);
+    private SingleThreadedClientServiceCache<Service> newCache(ScheduledExecutorService executor) {
+        SingleThreadedClientServiceCache<Service> cache = new SingleThreadedClientServiceCache<>(_cachingPolicy, _factory, executor, _registry);
         _caches.add(cache);
         return cache;
     }

--- a/perf-test-suite/README.md
+++ b/perf-test-suite/README.md
@@ -70,12 +70,26 @@ After determining and setting those desired values the suite will run the desire
       -m,--max-instances <arg>    Max instances per end point in service cache,
                                   default is 10
 
+      -g,--singleton-mode         Run with singleton policy mode, default is
+                                  false
+
+      -n,--eviction-ttl <arg>     Eviction TTL for bad clients in singleton
+                                  policy mode, default is 5 second
+                                  crunch hash, default is 1024 X 5 (5kb)
+
 ### Overall load tweaking parameters
 
       -t,--thread-size <arg>      # of workers threads to run, default is 100
 
       -w,--work-size <arg>        length of the string to generate randomly and
                                   crunch hash, default is 5120 (5kb)
+
+### Chaos parameter to cause havoc on cache
+
+      -c,--chaos-count <arg>      Number of chaos workers to use, default is 2
+
+      -l,--chaos-interval <arg>   time (in seconds) to wait between chaos,
+                                   default is 15
 
 ### I/O and runtime parameters
 
@@ -155,27 +169,37 @@ A CSV style output provides a number of metrics, it can either be STDOUT or if p
  
 Example:
 
-    counter,cr-totl,cr-mnrt,cr-1mrt,cr-5mrt,cr-15rt,dt-totl,dt-mnrt,dt-1mrt,dt-5mrt,dt-15rt,sc-totl,sc-mnrt,sc-1mrt,sc-5mrt,sc-15rt,co-totl,co-min,co-max,co-mean,co-1mrt,co-5mrt,co-15rt,ci-totl,ci-min,ci-max,ci-mean,ci-1mrt,ci-5mrt,ci-15rt,st-totl,st-min,st-max,st-mean,st-1mrt,st-5mrt,st-15rt,tt-totl,tt-min,tt-max,tt-mean,tt-1mrt,tt-5mrt,tt-15rt,
-    0,100,599.86,0.00,0.00,0.00,0,0.00,0.00,0.00,0.00,0,0.00,0.00,0.00,0.00,100,0.10,33.07,11.70,0.00,0.00,0.00,0,0.00,0.00,0.00,0.00,0.00,0.00,0,0.00,0.00,0.00,0.00,0.00,0.00,0,0.00,0.00,0.00,0.00,0.00,0.00,
-    1,1516,1286.03,0.00,0.00,0.00,0,0.00,0.00,0.00,0.00,1495,1346.02,0.00,0.00,0.00,1513,0.07,234.06,19.36,0.00,0.00,0.00,1497,0.02,232.63,8.97,0.00,0.00,0.00,1513,0.15,443.13,29.43,0.00,0.00,0.00,1500,0.36,538.90,58.12,0.00,0.00,0.00,
+    counter,cr-totl,cr-mnrt,cr-1mrt,cr-5mrt,cr-15rt,dt-totl,dt-mnrt,dt-1mrt,dt-5mrt,dt-15rt,\
+        sc-totl,sc-mnrt,sc-1mrt,sc-5mrt,sc-15rt,co-totl,co-min,co-max,co-mean,co-1mrt,co-5mrt,co-15rt,\
+        ci-totl,ci-min,ci-max,ci-mean,ci-1mrt,ci-5mrt,ci-15rt,st-totl,st-min,st-max,st-mean,st-1mrt,st-5mrt,st-15rt,\
+        tt-totl,tt-min,tt-max,tt-mean,tt-1mrt,tt-5mrt,tt-15rt,
+    0,100,599.86,0.00,0.00,0.00,0,0.00,0.00,0.00,0.00,0,0.00,0.00,0.00,0.00,100,0.10,33.07,11.70,0.00,0.00,0.00,0,\
+        0.00,0.00,0.00,0.00,0.00,0.00,0,0.00,0.00,0.00,0.00,0.00,0.00,0,0.00,0.00,0.00,0.00,0.00,0.00,
+    1,1516,1286.03,0.00,0.00,0.00,0,0.00,0.00,0.00,0.00,1495,1346.02,0.00,0.00,0.00,1513,0.07,\234.06,19.36,0.00,0.00,\
+        0.00,1497,0.02,232.63,8.97,0.00,0.00,0.00,1513,0.15,443.13,29.43,0.00,0.00,0.00,1500,0.36,538.90,58.12,0.00,0.00,0.00,
 
 
 #### Rolling statistics
 
 If requested (via --statistics / -s) a rolling statistics output on STDOUT provides the following metrics:
- 
-    service created & destroyed, with total count and 1 minute, 5 minute, 15 minute and mean rates
- 
-    service times (just the hash) & total time (service plus ostrich overhead) with total number of execution and 1 minute, 5 minute, 15 minute and mean rates of each execution
- 
-    checkin & checkout times with total number of check in and check outs, and 1 minute, 5 minute, 15 minute and mean rates of each check in and check out
 
-#### Example:
+    <Current date-time>
+    Running ## seconds of <total-runtime> with threads: ##, work size: ##, idle time: ##, max instance: ##, \
+            exhaust action: <>, singleton-mode: <>, eviction-ttl: ##, chaos-worker: ##, chaos-interval: ##
+    Called count: ####    Cache Miss: ####    Failed Count: ####    Service Created: ####    Service Destroyed: #### \
+            Chaos: ####    Stable: ####    Register: ####    Evict: ####    Load: ####
 
-    Running 5 seconds of 30 with threads: 25, work size: 12000, idle time: 10, max instance: 10, exhaust action: GROW
-        created / destroyed    -- total:     3651 /        0  1-min: 708.20/s / 0.00/s      5-min: 708.20/s / 0.00/s      15-min: 708.20/s / 0.00/s      mean: 706.61/s / 0.00/s
-        service / total        -- total:     3648 /     3648  1-min: 708.60/s / 719.60/s    5-min: 708.60/s / 719.60/s    15-min: 708.60/s / 719.60/s    mean: 5.24ms / 7.84ms
-        checkout / checkin     -- total:     3652 /     3649  1-min: 720.00/s / 719.60/s    5-min: 720.00/s / 719.60/s    15-min: 720.00/s / 719.60/s    mean: 1.73ms / 0.70ms
+    created / destroyed   -- 1-min: #.##/s / #.##/s    5-min: #.##/s / #.##/s      15-min: #.##/s / #.##/s    mean: #.##/s / #.##/s
+    chaos / stable        -- 1-min: #.##/s / #.##/s    5-min: #.##/s / #.##/s      15-min: #.##/s / #.##/s    mean: #.##/s / #.##/s
+    executed / failure    -- 1-min: #.##/s / #.##/s    5-min: #.##/s / #.##/s      15-min: #.##/s / #.##/s    mean: #.##/s / #.##/s
+    service / total       -- 1-min: #.##/s / #.##/s    5-min: #.##/s / #.##/s      15-min: #.##/s / #.##/s    mean: #.##/s / #.##/s
+    checkout / checkin    -- 1-min: #.##/s / #.##/s    5-min: #.##/s / #.##/s      15-min: #.##/s / #.##/s    mean: #.##/s / #.##/s
+
+    Service     -- mean: #.##ms    min: #.##ms    max: #.##ms    75th: #.##ms    95th: #.##ms    98th: #.##ms    99th: #.##ms    999th: #.##ms
+    Checkout    -- mean: #.##ms    min: #.##ms    max: #.##ms    75th: #.##ms    95th: #.##ms    98th: #.##ms    99th: #.##ms    999th: #.##ms
+    Checkin     -- mean: #.##ms    min: #.##ms    max: #.##ms    75th: #.##ms    95th: #.##ms    98th: #.##ms    99th: #.##ms    999th: #.##ms
+    Total       -- mean: #.##ms    min: #.##ms    max: #.##ms    75th: #.##ms    95th: #.##ms    98th: #.##ms    99th: #.##ms    999th: #.##ms
+
 
 ## Running Example
 

--- a/perf-test-suite/pom.xml
+++ b/perf-test-suite/pom.xml
@@ -16,7 +16,7 @@
     <version>0.1</version>
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
-        <ostrich.core.version>${parent.version}</ostrich.core.version>
+        <ostrich.core.version>${project.parent.version}</ostrich.core.version>
     </properties>
 
     <dependencies>

--- a/perf-test-suite/src/main/java/com/bazaarvoice/ostrich/perftest/core/SimpleServiceFactory.java
+++ b/perf-test-suite/src/main/java/com/bazaarvoice/ostrich/perftest/core/SimpleServiceFactory.java
@@ -1,7 +1,7 @@
 package com.bazaarvoice.ostrich.perftest.core;
 
 import com.bazaarvoice.ostrich.ServiceEndPoint;
-import com.bazaarvoice.ostrich.ServiceFactory;
+import com.bazaarvoice.ostrich.ThreadSafeServiceFactory;
 import com.bazaarvoice.ostrich.metrics.Metrics;
 import com.bazaarvoice.ostrich.perftest.utils.HashFunction;
 import com.bazaarvoice.ostrich.pool.ServicePoolBuilder;
@@ -12,12 +12,11 @@ import com.codahale.metrics.Timer;
 /**
  * A service factory, as needed in the ServiceCache
  */
-public class SimpleServiceFactory implements ServiceFactory<Service<String, String>> {
+public class SimpleServiceFactory implements ThreadSafeServiceFactory<Service<String, String>> {
 
     private final Meter _serviceCreated;
     private final Meter _serviceDestroyed;
     private final Timer _serviceTimer;
-
 
     /**
      * private constructor
@@ -74,33 +73,6 @@ public class SimpleServiceFactory implements ServiceFactory<Service<String, Stri
     @Override
     public boolean isRetriableException(Exception exception) {
         throw new RuntimeException("isRetriableException() should not get executed as part the performance test suite");
-    }
-
-    /**
-     * exposes the service created meter
-     *
-     * @return service created meter
-     */
-    public Meter getServiceCreated() {
-        return _serviceCreated;
-    }
-
-    /**
-     * exposes the service destroyed meter
-     *
-     * @return service destroyed meter
-     */
-    public Meter getServiceDestroyed() {
-        return _serviceDestroyed;
-    }
-
-    /**
-     * exposes the service timer meter
-     *
-     * @return service timer meter
-     */
-    public Timer getServiceTimer() {
-        return _serviceTimer;
     }
 
     /**

--- a/perf-test-suite/src/main/java/com/bazaarvoice/ostrich/perftest/utils/Arguments.java
+++ b/perf-test-suite/src/main/java/com/bazaarvoice/ostrich/perftest/utils/Arguments.java
@@ -25,10 +25,14 @@ public class Arguments {
     private long _runTimeSecond = Long.MAX_VALUE;
     private int _maxInstance = 10;
     private int _idleTimeSecond = 10;
+    private boolean _runSingletonMode = false;
+    private int _evictionTTL = 5;
     private ExhaustionAction _exhaustionAction = ExhaustionAction.WAIT;
     private int _reportingIntervalSeconds = 1;
     private PrintStream _output = System.out;
     private boolean _printStats = false;
+    private int _chaosWorkers = 2;
+    private int _chaosInterval = 15;
 
 
     public Arguments(String[] args) {
@@ -71,6 +75,22 @@ public class Arguments {
         return _reportingIntervalSeconds;
     }
 
+    public boolean isRunSingletonMode() {
+        return _runSingletonMode;
+    }
+
+    public int getEvictionTTL() {
+        return _evictionTTL;
+    }
+
+    public int getChaosWorkers() {
+        return _chaosWorkers;
+    }
+
+    public int getChaosInterval() {
+        return _chaosInterval;
+    }
+
     private void parseArgs(String[] args) {
 
         Options options = new Options();
@@ -84,6 +104,12 @@ public class Arguments {
         options.addOption("m", "max-instances", true, "Max instances per end point in service cache, default is 10");
         options.addOption("i", "idle-time", true, "Idle time before service cache should take evict action, default is 10");
         options.addOption("e", "exhaust-action", true, "Exhaust action when cache is exhausted, acceptable values are WAIT|FAIL|GROW, default is WAIT");
+
+        options.addOption("g", "singleton-mode", false, "Run with singleton policy mode, default is false");
+        options.addOption("n", "eviction-ttl", true, "Eviction TTL for bad clients in singleton policy mode, default is 5 second");
+
+        options.addOption("c", "chaos-count", true, "Number of chaos workers to use, default is 2");
+        options.addOption("l", "chaos-interval", true, "time (in seconds) to wait between chaos, default is 15");
 
         options.addOption("o", "output-file", true, "Output file to use instead of STDOUT");
         options.addOption("v", "report-every", true, "Reports the running statistics every # seconds");
@@ -129,16 +155,27 @@ public class Arguments {
                     case "o":
                         _output = createPrintStream(value);
                         break;
+                    case "g":
+                        _runSingletonMode = true;
+                        break;
+                    case "n":
+                        _evictionTTL = Integer.parseInt(value);
+                        break;
                     case "s":
                         _printStats = true;
                         break;
                     case "v":
                         _reportingIntervalSeconds = Integer.parseInt(value);
                         break;
+                    case "c":
+                        _chaosWorkers = Integer.parseInt(value);
+                        break;
+                    case "l":
+                        _chaosInterval = Integer.parseInt(value);
+                        break;
                 }
             }
             if (_output == System.out && _printStats) {
-
                 throw new Exception("Cannot print both report log and statistics to STDOUT at the same time");
             }
         } catch (IllegalArgumentException ex) {

--- a/perf-test-suite/src/main/java/com/bazaarvoice/ostrich/perftest/utils/ChaosRunner.java
+++ b/perf-test-suite/src/main/java/com/bazaarvoice/ostrich/perftest/utils/ChaosRunner.java
@@ -1,0 +1,59 @@
+package com.bazaarvoice.ostrich.perftest.utils;
+
+import com.bazaarvoice.ostrich.ServiceEndPoint;
+import com.bazaarvoice.ostrich.metrics.Metrics;
+import com.bazaarvoice.ostrich.perftest.core.Service;
+import com.bazaarvoice.ostrich.pool.ServiceCache;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+public class ChaosRunner {
+
+    private final ServiceCache<Service<String, String>> _serviceCache;
+    private final int _chaosWorkers;
+    private final Meter _chaosMeter, _stableMeter;
+    private final int _chaosInterval;
+
+    public ChaosRunner(ServiceCache<Service<String, String>> serviceCache, Arguments arguments, MetricRegistry metricRegistry) {
+        _serviceCache = serviceCache;
+        _chaosWorkers = arguments.getChaosWorkers();
+        Metrics.InstanceMetrics _metrics = Metrics.forInstance(metricRegistry, this, "ChaosRunner");
+        _chaosMeter = _metrics.meter("Chaos");
+        _stableMeter = _metrics.meter("Stable");
+        _chaosInterval = arguments.getChaosInterval();
+    }
+
+    public List<Thread> generateChaosWorkers() {
+        ImmutableList.Builder<Thread> chaosWorkersBuilder = ImmutableList.builder();
+        for(int i=0; i<_chaosWorkers; i++) {
+            Runnable runnable = new Runnable() {
+                @Override
+                public void run() {
+                    while(!Thread.interrupted()) {
+                        try {
+                            int sleepTime = Utilities.getRandomInt(_chaosInterval);
+                            Utilities.sleepForSeconds(sleepTime);
+                            String hashName = HashFunction.getRandomHashName();
+                            ServiceEndPoint endPoint = Utilities.buildServiceEndPoint(hashName);
+                            _serviceCache.evict(endPoint);
+                            _chaosMeter.mark();
+                            Utilities.sleepForSeconds(_chaosInterval - sleepTime);
+                            _serviceCache.register(endPoint);
+                            _stableMeter.mark();
+                        }
+                        catch(Exception ignored) {
+                            ignored.printStackTrace();
+                        }
+                    }
+                }
+            };
+            chaosWorkersBuilder.add(new Thread(runnable));
+        }
+        return chaosWorkersBuilder.build();
+    }
+
+
+}

--- a/perf-test-suite/src/main/java/com/bazaarvoice/ostrich/perftest/utils/HashFunction.java
+++ b/perf-test-suite/src/main/java/com/bazaarvoice/ostrich/perftest/utils/HashFunction.java
@@ -2,7 +2,8 @@ package com.bazaarvoice.ostrich.perftest.utils;
 
 import org.apache.commons.codec.digest.DigestUtils;
 
-import java.util.Random;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * Various singleton hash function to mimic workload
@@ -44,12 +45,12 @@ public enum HashFunction {
             return DigestUtils.md5Hex(work);
         }
     };
-    private static final int RANDOM_HASH_FUNCTION_LIMIT = HashFunction.values().length;
-    private static final Random RANDOM = new Random();
-
-    public static HashFunction getRandomHashFunction() {
-        return HashFunction.values()[RANDOM.nextInt(RANDOM_HASH_FUNCTION_LIMIT)];
-    }
 
     public abstract String process(String work);
+
+    private static final List<HashFunction> HASH_FUNCTION_LIST = Arrays.asList(HashFunction.values());
+
+    public static String getRandomHashName() {
+        return HASH_FUNCTION_LIST.get(Utilities.getRandomInt(HASH_FUNCTION_LIST.size())).name();
+    }
 }

--- a/perf-test-suite/src/main/java/com/bazaarvoice/ostrich/perftest/utils/LoadRunner.java
+++ b/perf-test-suite/src/main/java/com/bazaarvoice/ostrich/perftest/utils/LoadRunner.java
@@ -39,7 +39,7 @@ public class LoadRunner {
     private final Timer _checkoutTimer;
     private final Timer _checkinTimer;
     private final Timer _serviceTimer;
-    private final Timer totalTimer;
+    private final Timer _totalTimer;
     private final Timer _evictionTimer;
     private final Timer _registerTimer;
     private final Timer _loadTimer;
@@ -79,7 +79,7 @@ public class LoadRunner {
         _checkoutTimer = metricRegistry.timer("com.bazaarvoice.ostrich.pool.ServiceRunner.ServiceRunner.Checkout");
         _checkinTimer = metricRegistry.timer("com.bazaarvoice.ostrich.pool.ServiceRunner.ServiceRunner.Checkin");
         _serviceTimer = metricRegistry.timer("com.bazaarvoice.ostrich.perftest.core.SimpleServiceFactory.ServiceFactory.Timer");
-        totalTimer = metricRegistry.timer("com.bazaarvoice.ostrich.pool.ServiceRunner.ServiceRunner.Total");
+        _totalTimer = metricRegistry.timer("com.bazaarvoice.ostrich.pool.ServiceRunner.ServiceRunner.Total");
         if(arguments.isRunSingletonMode()) {
             _evictionTimer = metricRegistry.timer("com.bazaarvoice.ostrich.pool.MultiThreadedClientServiceCache.SimpleService.eviction-time");
             _registerTimer = metricRegistry.timer("com.bazaarvoice.ostrich.pool.MultiThreadedClientServiceCache.SimpleService.register-time");
@@ -111,7 +111,7 @@ public class LoadRunner {
         Snapshot checkoutTimerSnapshot = _checkoutTimer.getSnapshot();
         Snapshot checkinTimerSnapshot = _checkinTimer.getSnapshot();
         Snapshot serviceTimerSnapshot = _serviceTimer.getSnapshot();
-        Snapshot totalTimerSnapshot = totalTimer.getSnapshot();
+        Snapshot totalTimerSnapshot = _totalTimer.getSnapshot();
 
         _out.print(String.format("%d,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,",
                 _checkoutTimer.getCount(), nsToMs(checkoutTimerSnapshot.getMin()),
@@ -126,9 +126,10 @@ public class LoadRunner {
                 nsToMs(serviceTimerSnapshot.getMax()), nsToMs(serviceTimerSnapshot.getMean()),
                 _serviceTimer.getOneMinuteRate(), _serviceTimer.getFiveMinuteRate(), _serviceTimer.getFifteenMinuteRate()));
         _out.print(String.format("%d,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,",
-                totalTimer.getCount(), nsToMs(totalTimerSnapshot.getMin()),
+                _totalTimer.getCount(), nsToMs(totalTimerSnapshot.getMin()),
                 nsToMs(totalTimerSnapshot.getMax()), nsToMs(totalTimerSnapshot.getMean()),
-                totalTimer.getOneMinuteRate(), totalTimer.getFiveMinuteRate(), totalTimer.getFifteenMinuteRate()));
+                _totalTimer.getOneMinuteRate(), _totalTimer.getFiveMinuteRate(), _totalTimer.getFifteenMinuteRate()));
+
 
         _out.println();
         _out.flush();
@@ -177,10 +178,10 @@ public class LoadRunner {
 
             System.out.println(String.format("\tservice / total\t\t-- 1-min: %3.2f/s / %3.2f/s" +
                             "\t5-min: %3.2f/s / %3.2f/s  \t15-min: %3.2f/s / %3.2f/s\tmean: %3.2f/s / %3.2f/s",
-                    _serviceTimer.getOneMinuteRate(), totalTimer.getOneMinuteRate(),
-                    _serviceTimer.getFiveMinuteRate(), totalTimer.getFiveMinuteRate(),
-                    _serviceTimer.getFifteenMinuteRate(), totalTimer.getFifteenMinuteRate(),
-                    _serviceTimer.getMeanRate(), totalTimer.getMeanRate()));
+                    _serviceTimer.getOneMinuteRate(), _totalTimer.getOneMinuteRate(),
+                    _serviceTimer.getFiveMinuteRate(), _totalTimer.getFiveMinuteRate(),
+                    _serviceTimer.getFifteenMinuteRate(), _totalTimer.getFifteenMinuteRate(),
+                    _serviceTimer.getMeanRate(), _totalTimer.getMeanRate()));
 
             System.out.println(String.format("\tcheckout / checkin\t-- 1-min: %3.2f/s / %3.2f/s" +
                             "\t5-min: %3.2f/s / %3.2f/s  \t15-min: %3.2f/s / %3.2f/s\tmean: %3.2f/s / %3.2f/s",

--- a/perf-test-suite/src/main/java/com/bazaarvoice/ostrich/perftest/utils/LoadRunner.java
+++ b/perf-test-suite/src/main/java/com/bazaarvoice/ostrich/perftest/utils/LoadRunner.java
@@ -1,13 +1,17 @@
 package com.bazaarvoice.ostrich.perftest.utils;
 
+import com.bazaarvoice.ostrich.ThreadSafeServiceFactory;
+import com.bazaarvoice.ostrich.perftest.core.Service;
 import com.bazaarvoice.ostrich.perftest.core.SimpleServiceFactory;
 import com.bazaarvoice.ostrich.pool.ServiceRunner;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Snapshot;
 import com.codahale.metrics.Timer;
+import com.google.common.collect.Lists;
 
 import java.io.PrintStream;
+import java.util.Date;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -20,75 +24,107 @@ public class LoadRunner {
     private final PrintStream _out;
     private final boolean _doPrintStats;
     private final long _totalRuntime;
-    private final SimpleServiceFactory _serviceFactory;
-    private final ServiceRunner _serviceRunner;
     private final List<Thread> _workers;
     private final long _startTime;
     private final int _reportingIntervalSeconds;
     private final Arguments _arguments;
+
+    private final Meter _serviceCreated;
+    private final Meter _serviceDestroyed;
+    private final Meter _serviceCalled;
+    private final Meter _cacheMissed;
+    private final Meter _serviceFailed;
+    private final Meter _chaosCreated;
+    private final Meter _stableCreated;
+    private final Timer _checkoutTimer;
+    private final Timer _checkinTimer;
+    private final Timer _serviceTimer;
+    private final Timer totalTimer;
+    private final Timer _evictionTimer;
+    private final Timer _registerTimer;
+    private final Timer _loadTimer;
+
     private long _counter = 0;
 
     public LoadRunner(Arguments arguments) {
 
         MetricRegistry metricRegistry = new MetricRegistry();
-        _arguments = arguments;
+        ThreadSafeServiceFactory<Service<String, String>> serviceFactory = SimpleServiceFactory.newInstance(metricRegistry);
+        ServiceRunner serviceRunner = new ServiceRunner(serviceFactory, metricRegistry, arguments);
+        ChaosRunner chaosRunner = new ChaosRunner(serviceRunner.getServiceCache(), arguments, metricRegistry);
 
-        this._serviceFactory = SimpleServiceFactory.newInstance(metricRegistry);
-        this._serviceRunner = new ServiceRunner(_serviceFactory, metricRegistry, _arguments);
-        this._workers = _serviceRunner.generateWorkers();
-        this._out = arguments.getOutput();
-        this._doPrintStats = arguments.doPrintStats();
-        this._totalRuntime = arguments.getRunTimeSecond();
-        this._reportingIntervalSeconds = arguments.getReportingIntervalSeconds();
+        _arguments = arguments;
+        _out = arguments.getOutput();
+        _doPrintStats = arguments.doPrintStats();
+        _totalRuntime = arguments.getRunTimeSecond();
+        _reportingIntervalSeconds = arguments.getReportingIntervalSeconds();
+
+        _workers = Lists.newArrayList();
+        _workers.addAll(serviceRunner.generateWorkers());
+        _workers.addAll(chaosRunner.generateChaosWorkers());
 
         for (Thread thread : _workers) {
             thread.start();
         }
 
-        this._startTime = currentTimeSeconds();
+        _startTime = currentTimeSeconds();
+
+        _serviceCreated = metricRegistry.meter("com.bazaarvoice.ostrich.perftest.core.SimpleServiceFactory.ServiceFactory.Created");
+        _serviceDestroyed = metricRegistry.meter("com.bazaarvoice.ostrich.perftest.core.SimpleServiceFactory.ServiceFactory.Destroyed");
+        _serviceCalled = metricRegistry.meter("com.bazaarvoice.ostrich.pool.ServiceRunner.ServiceRunner.Executed");
+        _cacheMissed = metricRegistry.meter("com.bazaarvoice.ostrich.pool.ServiceRunner.ServiceRunner.Cache-Miss");
+        _serviceFailed = metricRegistry.meter("com.bazaarvoice.ostrich.pool.ServiceRunner.ServiceRunner.Failure");
+        _chaosCreated = metricRegistry.meter("com.bazaarvoice.ostrich.perftest.utils.ChaosRunner.ChaosRunner.Chaos");
+        _stableCreated = metricRegistry.meter("com.bazaarvoice.ostrich.perftest.utils.ChaosRunner.ChaosRunner.Stable");
+        _checkoutTimer = metricRegistry.timer("com.bazaarvoice.ostrich.pool.ServiceRunner.ServiceRunner.Checkout");
+        _checkinTimer = metricRegistry.timer("com.bazaarvoice.ostrich.pool.ServiceRunner.ServiceRunner.Checkin");
+        _serviceTimer = metricRegistry.timer("com.bazaarvoice.ostrich.perftest.core.SimpleServiceFactory.ServiceFactory.Timer");
+        totalTimer = metricRegistry.timer("com.bazaarvoice.ostrich.pool.ServiceRunner.ServiceRunner.Total");
+        if(arguments.isRunSingletonMode()) {
+            _evictionTimer = metricRegistry.timer("com.bazaarvoice.ostrich.pool.MultiThreadedClientServiceCache.SimpleService.eviction-time");
+            _registerTimer = metricRegistry.timer("com.bazaarvoice.ostrich.pool.MultiThreadedClientServiceCache.SimpleService.register-time");
+            _loadTimer = metricRegistry.timer("dummy");
+        }
+        else {
+            _loadTimer = metricRegistry.timer("com.bazaarvoice.ostrich.pool.SingleThreadedClientServiceCache.SimpleService.load-time");
+            _evictionTimer = _registerTimer = metricRegistry.timer("dummy");
+        }
+
     }
 
     public void printLog() {
 
         long currentRuntime = currentTimeSeconds() - _startTime;
 
-        Meter serviceCreated = _serviceFactory.getServiceCreated();
-        Meter serviceDestroyed = _serviceFactory.getServiceDestroyed();
-        Meter serviceCalled = _serviceRunner.getServiceMeter();
-        Timer checkoutTimer = _serviceRunner.getCheckoutTimer();
-        Timer checkinTimer = _serviceRunner.getCheckinTimer();
-        Timer serviceTimer = _serviceFactory.getServiceTimer();
-        Timer totalTimer = _serviceRunner.getTotalExecTimer();
-
         _out.print(String.format("%d,", _counter++));
 
         _out.print(String.format("%d,%.2f,%.2f,%.2f,%.2f,",
-                serviceCreated.getCount(), serviceCreated.getMeanRate(), serviceCreated.getOneMinuteRate(),
-                serviceCreated.getFiveMinuteRate(), serviceCreated.getFifteenMinuteRate()));
+                _serviceCreated.getCount(), _serviceCreated.getMeanRate(), _serviceCreated.getOneMinuteRate(),
+                _serviceCreated.getFiveMinuteRate(), _serviceCreated.getFifteenMinuteRate()));
         _out.print(String.format("%d,%.2f,%.2f,%.2f,%.2f,",
-                serviceDestroyed.getCount(), serviceDestroyed.getMeanRate(), serviceDestroyed.getOneMinuteRate(),
-                serviceDestroyed.getFiveMinuteRate(), serviceDestroyed.getFifteenMinuteRate()));
+                _serviceDestroyed.getCount(), _serviceDestroyed.getMeanRate(), _serviceDestroyed.getOneMinuteRate(),
+                _serviceDestroyed.getFiveMinuteRate(), _serviceDestroyed.getFifteenMinuteRate()));
         _out.print(String.format("%d,%.2f,%.2f,%.2f,%.2f,",
-                serviceCalled.getCount(), serviceCalled.getMeanRate(), serviceCalled.getOneMinuteRate(),
-                serviceCalled.getFiveMinuteRate(), serviceCalled.getFifteenMinuteRate()));
+                _serviceCalled.getCount(), _serviceCalled.getMeanRate(), _serviceCalled.getOneMinuteRate(),
+                _serviceCalled.getFiveMinuteRate(), _serviceCalled.getFifteenMinuteRate()));
 
-        Snapshot checkoutTimerSnapshot = checkoutTimer.getSnapshot();
-        Snapshot checkinTimerSnapshot = checkinTimer.getSnapshot();
-        Snapshot serviceTimerSnapshot = serviceTimer.getSnapshot();
+        Snapshot checkoutTimerSnapshot = _checkoutTimer.getSnapshot();
+        Snapshot checkinTimerSnapshot = _checkinTimer.getSnapshot();
+        Snapshot serviceTimerSnapshot = _serviceTimer.getSnapshot();
         Snapshot totalTimerSnapshot = totalTimer.getSnapshot();
 
         _out.print(String.format("%d,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,",
-                checkoutTimer.getCount(), nsToMs(checkoutTimerSnapshot.getMin()),
+                _checkoutTimer.getCount(), nsToMs(checkoutTimerSnapshot.getMin()),
                 nsToMs(checkoutTimerSnapshot.getMax()), nsToMs(checkoutTimerSnapshot.getMean()),
-                checkoutTimer.getOneMinuteRate(), checkoutTimer.getFiveMinuteRate(), checkoutTimer.getFifteenMinuteRate()));
+                _checkoutTimer.getOneMinuteRate(), _checkoutTimer.getFiveMinuteRate(), _checkoutTimer.getFifteenMinuteRate()));
         _out.print(String.format("%d,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,",
-                checkinTimer.getCount(), nsToMs(checkinTimerSnapshot.getMin()),
+                _checkinTimer.getCount(), nsToMs(checkinTimerSnapshot.getMin()),
                 nsToMs(checkinTimerSnapshot.getMax()), nsToMs(checkinTimerSnapshot.getMean()),
-                checkinTimer.getOneMinuteRate(), checkinTimer.getFiveMinuteRate(), checkinTimer.getFifteenMinuteRate()));
+                _checkinTimer.getOneMinuteRate(), _checkinTimer.getFiveMinuteRate(), _checkinTimer.getFifteenMinuteRate()));
         _out.print(String.format("%d,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,",
-                serviceTimer.getCount(), nsToMs(serviceTimerSnapshot.getMin()),
+                _serviceTimer.getCount(), nsToMs(serviceTimerSnapshot.getMin()),
                 nsToMs(serviceTimerSnapshot.getMax()), nsToMs(serviceTimerSnapshot.getMean()),
-                serviceTimer.getOneMinuteRate(), serviceTimer.getFiveMinuteRate(), serviceTimer.getFifteenMinuteRate()));
+                _serviceTimer.getOneMinuteRate(), _serviceTimer.getFiveMinuteRate(), _serviceTimer.getFifteenMinuteRate()));
         _out.print(String.format("%d,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,",
                 totalTimer.getCount(), nsToMs(totalTimerSnapshot.getMin()),
                 nsToMs(totalTimerSnapshot.getMax()), nsToMs(totalTimerSnapshot.getMean()),
@@ -100,33 +136,58 @@ public class LoadRunner {
         if (_doPrintStats) {
             System.out.print("\u001b[2J");
 
+            System.out.println(new Date());
+
             System.out.println(String.format("Running %d seconds of %s with threads: %d, work size: %d, idle time: %d, " +
-                            "max instance: %d, exhaust action: %s",
+                            "max instance: %d, exhaust action: %s, singleton-mode: %s, eviction-ttl: %d, chaos-worker: %d, chaos-interval: %d",
                     currentRuntime, _arguments.getRunTimeSecond(), _arguments.getThreadSize(), _arguments.getWorkSize(),
-                    _arguments.getIdleTimeSecond(), _arguments.getMaxInstance(), _arguments.getExhaustionAction().name()));
+                    _arguments.getIdleTimeSecond(), _arguments.getMaxInstance(), _arguments.getExhaustionAction().name(),
+                    _arguments.isRunSingletonMode(), _arguments.getEvictionTTL(),
+                    _arguments.getChaosWorkers(), _arguments.getChaosInterval()));
+
+            System.out.println(String.format("Called count: %d\tCache Miss: %d\tFailed Count: %d\tService Created: %d" +
+                            "\tService Destroyed: %d\tChaos: %d\tStable: %d\tRegister: %d\tEvict: %d\tLoad: %d",
+                    _serviceCalled.getCount(), _cacheMissed.getCount(), _serviceFailed.getCount(),
+                    _serviceCreated.getCount(), _serviceDestroyed.getCount(),
+                    _chaosCreated.getCount(), _stableCreated.getCount(),
+                    _registerTimer.getCount(), _evictionTimer.getCount(), _loadTimer.getCount()));
 
             System.out.println();
 
             System.out.println(String.format("\tcreated / destroyed\t-- 1-min: %3.2f/s / %3.2f/s" +
                             "\t5-min: %3.2f/s / %3.2f/s  \t15-min: %3.2f/s / %3.2f/s\tmean: %3.2f/s / %3.2f/s",
-                    serviceCreated.getOneMinuteRate(), serviceDestroyed.getOneMinuteRate(),
-                    serviceCreated.getFiveMinuteRate(), serviceDestroyed.getFiveMinuteRate(),
-                    serviceCreated.getFifteenMinuteRate(), serviceDestroyed.getFifteenMinuteRate(),
-                    serviceCreated.getMeanRate(), serviceDestroyed.getMeanRate()));
+                    _serviceCreated.getOneMinuteRate(), _serviceDestroyed.getOneMinuteRate(),
+                    _serviceCreated.getFiveMinuteRate(), _serviceDestroyed.getFiveMinuteRate(),
+                    _serviceCreated.getFifteenMinuteRate(), _serviceDestroyed.getFifteenMinuteRate(),
+                    _serviceCreated.getMeanRate(), _serviceDestroyed.getMeanRate()));
+
+            System.out.println(String.format("\tchaos / stable\t\t-- 1-min: %3.2f/s / %3.2f/s" +
+                            "\t5-min: %3.2f/s / %3.2f/s  \t15-min: %3.2f/s / %3.2f/s\tmean: %3.2f/s / %3.2f/s",
+                    _chaosCreated.getOneMinuteRate(), _stableCreated.getOneMinuteRate(),
+                    _chaosCreated.getFiveMinuteRate(), _stableCreated.getFiveMinuteRate(),
+                    _chaosCreated.getFifteenMinuteRate(), _stableCreated.getFifteenMinuteRate(),
+                    _chaosCreated.getMeanRate(), _stableCreated.getMeanRate()));
+
+            System.out.println(String.format("\texecuted / failure\t-- 1-min: %3.2f/s / %3.2f/s" +
+                            "\t5-min: %3.2f/s / %3.2f/s  \t15-min: %3.2f/s / %3.2f/s\tmean: %3.2f/s / %3.2f/s",
+                    _serviceCalled.getOneMinuteRate(), _serviceFailed.getOneMinuteRate(),
+                    _serviceCalled.getFiveMinuteRate(), _serviceFailed.getFiveMinuteRate(),
+                    _serviceCalled.getFifteenMinuteRate(), _serviceFailed.getFifteenMinuteRate(),
+                    _serviceCalled.getMeanRate(), _serviceFailed.getMeanRate()));
 
             System.out.println(String.format("\tservice / total\t\t-- 1-min: %3.2f/s / %3.2f/s" +
                             "\t5-min: %3.2f/s / %3.2f/s  \t15-min: %3.2f/s / %3.2f/s\tmean: %3.2f/s / %3.2f/s",
-                    serviceTimer.getOneMinuteRate(), totalTimer.getOneMinuteRate(),
-                    serviceTimer.getFiveMinuteRate(), totalTimer.getFiveMinuteRate(),
-                    serviceTimer.getFifteenMinuteRate(), totalTimer.getFifteenMinuteRate(),
-                    serviceTimer.getMeanRate(), totalTimer.getMeanRate()));
+                    _serviceTimer.getOneMinuteRate(), totalTimer.getOneMinuteRate(),
+                    _serviceTimer.getFiveMinuteRate(), totalTimer.getFiveMinuteRate(),
+                    _serviceTimer.getFifteenMinuteRate(), totalTimer.getFifteenMinuteRate(),
+                    _serviceTimer.getMeanRate(), totalTimer.getMeanRate()));
 
             System.out.println(String.format("\tcheckout / checkin\t-- 1-min: %3.2f/s / %3.2f/s" +
                             "\t5-min: %3.2f/s / %3.2f/s  \t15-min: %3.2f/s / %3.2f/s\tmean: %3.2f/s / %3.2f/s",
-                    checkoutTimer.getOneMinuteRate(), checkinTimer.getOneMinuteRate(),
-                    checkoutTimer.getFiveMinuteRate(), checkinTimer.getFiveMinuteRate(),
-                    checkoutTimer.getFifteenMinuteRate(), checkinTimer.getFifteenMinuteRate(),
-                    checkoutTimer.getMeanRate(), checkinTimer.getMeanRate()));
+                    _checkoutTimer.getOneMinuteRate(), _checkinTimer.getOneMinuteRate(),
+                    _checkoutTimer.getFiveMinuteRate(), _checkinTimer.getFiveMinuteRate(),
+                    _checkoutTimer.getFifteenMinuteRate(), _checkinTimer.getFifteenMinuteRate(),
+                    _checkoutTimer.getMeanRate(), _checkinTimer.getMeanRate()));
 
             System.out.println();
 

--- a/perf-test-suite/src/main/java/com/bazaarvoice/ostrich/perftest/utils/Utilities.java
+++ b/perf-test-suite/src/main/java/com/bazaarvoice/ostrich/perftest/utils/Utilities.java
@@ -1,0 +1,38 @@
+package com.bazaarvoice.ostrich.perftest.utils;
+
+import com.bazaarvoice.ostrich.ServiceEndPoint;
+import com.bazaarvoice.ostrich.ServiceEndPointBuilder;
+
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+public class Utilities {
+
+    private static final ThreadLocalRandom RANDOM = ThreadLocalRandom.current();
+    private Utilities() {
+    }
+
+    /**
+     * Creates a service endpoint to hash a string with a given hash function
+     *
+     * @param hashFunctionName to delegate the work
+     * @return an appropriate service endpoint for the job
+     */
+    public static ServiceEndPoint buildServiceEndPoint(String hashFunctionName) {
+        return new ServiceEndPointBuilder()
+                .withServiceName(hashFunctionName)
+                .withId(hashFunctionName)
+                .build();
+    }
+
+    public static void sleepForSeconds(int seconds) {
+        try {
+            Thread.sleep(TimeUnit.SECONDS.toMillis(seconds));
+        } catch (InterruptedException ignored) {
+        }
+    }
+
+    public static int getRandomInt(int limit) {
+        return RANDOM.nextInt(limit);
+    }
+}

--- a/perf-test-suite/src/main/java/com/bazaarvoice/ostrich/pool/ServiceRunner.java
+++ b/perf-test-suite/src/main/java/com/bazaarvoice/ostrich/pool/ServiceRunner.java
@@ -1,8 +1,8 @@
 package com.bazaarvoice.ostrich.pool;
 
 import com.bazaarvoice.ostrich.ServiceEndPoint;
-import com.bazaarvoice.ostrich.ServiceEndPointBuilder;
-import com.bazaarvoice.ostrich.ServiceFactory;
+import com.bazaarvoice.ostrich.ThreadSafeServiceFactory;
+import com.bazaarvoice.ostrich.exceptions.NoCachedInstancesAvailableException;
 import com.bazaarvoice.ostrich.metrics.Metrics;
 import com.bazaarvoice.ostrich.perftest.core.Result;
 import com.bazaarvoice.ostrich.perftest.core.ResultFactory;
@@ -10,6 +10,7 @@ import com.bazaarvoice.ostrich.perftest.core.Service;
 import com.bazaarvoice.ostrich.perftest.core.SimpleResultFactory;
 import com.bazaarvoice.ostrich.perftest.utils.Arguments;
 import com.bazaarvoice.ostrich.perftest.utils.HashFunction;
+import com.bazaarvoice.ostrich.perftest.utils.Utilities;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
@@ -33,70 +34,56 @@ public class ServiceRunner {
     private final ResultFactory<String> _resultFactory;
 
     private final Meter _serviceMeter;
+    private final Meter _cacheMissMeter;
+    private final Meter _failureMeter;
     private final Timer _checkoutTimer;
     private final Timer _checkinTimer;
     private final Timer _totalExecTimer;
-
 
     /**
      * @param serviceFactory the service factory
      * @param arguments      the command line arguments
      */
-    public ServiceRunner(ServiceFactory<Service<String, String>> serviceFactory, MetricRegistry metricRegistry, Arguments arguments) {
+    public ServiceRunner(ThreadSafeServiceFactory<Service<String, String>> serviceFactory, MetricRegistry metricRegistry, Arguments arguments) {
         _workSize = arguments.getWorkSize();
         _threadSize = arguments.getThreadSize();
         _resultFactory = SimpleResultFactory.newInstance();
 
-        ServiceCachingPolicy _cachingPolicy = new ServiceCachingPolicyBuilder()
-                .withCacheExhaustionAction(arguments.getExhaustionAction())
-                .withMaxNumServiceInstancesPerEndPoint(arguments.getMaxInstance())
-                .withMaxServiceInstanceIdleTime(arguments.getIdleTimeSecond(), TimeUnit.SECONDS)
-                .build();
-        _serviceCache = new ServiceCache<>(_cachingPolicy, serviceFactory, new MetricRegistry());
+        ServiceCachingPolicy cachingPolicy;
+        if(arguments.isRunSingletonMode()) {
+            cachingPolicy = ServiceCachingPolicyBuilder.newMultiThreadedClientPolicy(arguments.getEvictionTTL());
+        }
+        else {
+            cachingPolicy = new ServiceCachingPolicyBuilder()
+                    .withCacheExhaustionAction(arguments.getExhaustionAction())
+                    .withMaxNumServiceInstancesPerEndPoint(arguments.getMaxInstance())
+                    .withMaxServiceInstanceIdleTime(arguments.getIdleTimeSecond(), TimeUnit.SECONDS)
+                    .build();
+        }
+
+        _serviceCache = new ServiceCacheBuilder<Service<String, String>>()
+                .withMetricRegistry(metricRegistry)
+                .withServiceFactory(serviceFactory)
+                .withCachingPolicy(cachingPolicy).build();
 
         Metrics.InstanceMetrics _metrics = Metrics.forInstance(metricRegistry, this, "ServiceRunner");
         _serviceMeter = _metrics.meter("Executed");
+        _cacheMissMeter = _metrics.meter("Cache-Miss");
+        _failureMeter = _metrics.meter("Failure");
         _checkoutTimer = _metrics.timer("Checkout");
         _checkinTimer = _metrics.timer("Checkin");
         _totalExecTimer = _metrics.timer("Total");
     }
 
-    /**
-     * Creates a service endpoint to hash a string with a given hash function
-     *
-     * @param hashFunction to delegate the work
-     * @param payload      the string to hash
-     * @return an appropriate service endpoint for the job
-     */
-    private static ServiceEndPoint buildServiceEndPoint(HashFunction hashFunction, String payload) {
-        return new ServiceEndPointBuilder()
-                .withServiceName(hashFunction.name())
-                .withId(hashFunction.name())
-                .withPayload(payload)
-                .build();
-    }
-
-    public Meter getServiceMeter() {
-        return _serviceMeter;
-    }
-
-    public Timer getCheckoutTimer() {
-        return _checkoutTimer;
-    }
-
-    public Timer getCheckinTimer() {
-        return _checkinTimer;
-    }
-
-    public Timer getTotalExecTimer() {
-        return _totalExecTimer;
+    public ServiceCache<Service<String, String>> getServiceCache() {
+        return _serviceCache;
     }
 
     /**
      * Generates worker threads that will make requests of the ServiceCache.
      * Each worker thread will request a "Client" from the ServiceCache, and
-     * when it has a client will do some "busywork". The "busywork" will be
-     * to run some cryptographic hashes across a random string.
+     * when it has a client will do some "busywork". The "busywork" is running
+     * some cryptographic hashes on a random string.
      * The size of the random String to be hashed can be configured from the command line.
      */
     public List<Thread> generateWorkers() {
@@ -110,9 +97,9 @@ public class ServiceRunner {
                 public void run() {
                     while (!Thread.interrupted()) {
                         String work = RandomStringUtils.random(_workSize);
-                        HashFunction hashFunction = HashFunction.getRandomHashFunction();
-                        ServiceEndPoint serviceEndPoint = buildServiceEndPoint(hashFunction, work);
-                        serviceExecution(serviceEndPoint);
+                        String hashName = HashFunction.getRandomHashName();
+                        ServiceEndPoint serviceEndPoint = Utilities.buildServiceEndPoint(hashName);
+                        serviceExecution(serviceEndPoint, work);
                     }
                 }
             };
@@ -122,7 +109,7 @@ public class ServiceRunner {
         return threadListBuilder.build();
     }
 
-    private Result<String> serviceExecution(ServiceEndPoint serviceEndPoint) {
+    private Result<String> serviceExecution(ServiceEndPoint serviceEndPoint, String work) {
         Timer.Context totalTimeContext = _totalExecTimer.time();
         try {
             Timer.Context checkoutTimeContext = _checkoutTimer.time();
@@ -130,18 +117,22 @@ public class ServiceRunner {
             Service<String, String> service = serviceHandle.getService();
             checkoutTimeContext.stop();
 
-            String work = serviceEndPoint.getPayload();
             String result = service.process(work);
 
             Timer.Context checkinTimeContext = _checkinTimer.time();
             _serviceCache.checkIn(serviceHandle);
             checkinTimeContext.stop();
+            _serviceMeter.mark();
 
             return _resultFactory.createResponse(result);
+        } catch (NoCachedInstancesAvailableException exception) {
+            _cacheMissMeter.mark();
+            return _resultFactory.createResponse(exception);
         } catch (Exception exception) {
+            exception.printStackTrace();
+            _failureMeter.mark();
             return _resultFactory.createResponse(exception);
         } finally {
-            _serviceMeter.mark();
             totalTimeContext.stop();
         }
     }


### PR DESCRIPTION
This mimics a service cache that maintains a map of singleton service handles per endpoint, and eliminates the need for the cache checkout/checkin altogether.