### PR TITLE
Implement MultiThreaded and SingleThreaded service cache

### DIFF
--- a/core/src/main/java/com/bazaarvoice/ostrich/MultiThreadedServiceFactory.java
+++ b/core/src/main/java/com/bazaarvoice/ostrich/MultiThreadedServiceFactory.java
@@ -1,0 +1,12 @@
+package com.bazaarvoice.ostrich;
+
+/**
+ * The Multi threaded service factory creates thread safe service instances
+ *
+ * This applies to heavy weight clients, such as {@code HttpClient},
+ * {@code JestClient}, {@code ElasticSearchClient}, etc.
+ *
+ * @param <S>  the type parameter for the service
+ */
+public interface MultiThreadedServiceFactory<S> extends ServiceFactory<S> {
+}

--- a/core/src/main/java/com/bazaarvoice/ostrich/pool/MultiThreadedClientServiceCache.java
+++ b/core/src/main/java/com/bazaarvoice/ostrich/pool/MultiThreadedClientServiceCache.java
@@ -1,0 +1,361 @@
+package com.bazaarvoice.ostrich.pool;
+
+import com.bazaarvoice.ostrich.MultiThreadedServiceFactory;
+import com.bazaarvoice.ostrich.ServiceEndPoint;
+import com.bazaarvoice.ostrich.ServiceFactory;
+import com.bazaarvoice.ostrich.metrics.Metrics;
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Maps;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import static com.bazaarvoice.ostrich.pool.ServiceCacheBuilder.buildDefaultExecutor;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+/**
+ * A ServiceCache for "heavy weight" client instances, i.e. ones that are already thread safe.
+ * Therefore unlike {@link com.bazaarvoice.ostrich.pool.SingleThreadedClientServiceCache}, we
+ * can just map EndPoints to a single shared instance of a "heavy weight" client.
+ * <p/>
+ * This applies to third party client libraries for connecting to generic or specialized
+ * services, i.e. {@code HttpClient}, {@code JestClient}, {@code ElasticSearchClient} etc.
+ * <p/>
+ * If your client library is multi-thread safe, this ServiceCache should provide better
+ * performance than the {@link com.bazaarvoice.ostrich.pool.SingleThreadedClientServiceCache}.
+ *
+ * @param <S> the Service type
+ */
+public class MultiThreadedClientServiceCache<S> implements ServiceCache<S> {
+    private static final Logger LOG = LoggerFactory.getLogger(MultiThreadedClientServiceCache.class);
+
+    // Grace period during which a new service instance will not be replaced by subsequent registrations
+    // of the same end point.
+    private static final long DUP_REGISTRATION_WINDOW_MILLIS = SECONDS.toMillis(1);
+    private static final int DEFAULT_CLEANUP_DELAY_SECONDS = 15;
+    private static final int DEFAULT_EVICTION_DELAY_SECONDS = (int) MINUTES.toSeconds(3);
+
+    /**
+     * We want to be able to perform more than 300 checkOuts and checkIns per second.
+     * Thus we would like those methods to use an un-synchronized / non-blocking Map implementation.
+     * <p/>
+     * In order to do that we use a Copy-On-Write approach where all modifications
+     * (new EndPoint, EndPoint goes away, etc) will create a new Map instance.  This is acceptable as
+     * EndPoint addition / removal events are rare compared to checkIns and checkOuts.
+     * <p/>
+     * Because we are changing the pointer that is "_instancesPerEndpoint", we have to use the volatile
+     * keyword to force any thread that accesses the map to have the latest reference to it. There is a
+     * performance penalty associated with volatile, but it is better than synchronization.
+     */
+    private volatile Map<ServiceEndPoint, HeavyServiceHandle<S>> _instancesPerEndpoint = Maps.newHashMap();
+    private volatile boolean _isClosed;
+
+    private final Metrics.InstanceMetrics _metrics;
+    private final Timer _registerTimer;
+    private final Timer _evictionTimer;
+    private final Counter _serviceCounter;
+    private final ServiceFactory<S> _serviceFactory;
+    private final Future<?> _cleanupFuture;
+    private final ScheduledExecutorService _cleanupExecutor;
+    private final long _evictionDelayInMilliSeconds;
+
+    /**
+     * ServiceHandle that also tracks eviction and freshness status
+     */
+    private class HeavyServiceHandle<T extends S> extends ServiceHandle<S> {
+
+        private final long _sellByDate;
+        private volatile long _expireAfterDate = Long.MAX_VALUE;
+
+        public HeavyServiceHandle(T service, ServiceEndPoint endPoint) {
+            super(service, endPoint);
+
+            _sellByDate = System.currentTimeMillis() + DUP_REGISTRATION_WINDOW_MILLIS;
+        }
+
+        public boolean isOld() {
+            return System.currentTimeMillis() > _sellByDate;
+        }
+
+        public boolean hasBeenFlaggedForEviction() {
+            return _expireAfterDate != Long.MAX_VALUE;
+        }
+
+        public boolean timeToEvict() {
+            return _expireAfterDate != Long.MAX_VALUE && System.currentTimeMillis() > _expireAfterDate;
+        }
+
+        public void flagAsEvicted() {
+            if (_expireAfterDate == Long.MAX_VALUE) {
+                // Not synchronized - evictionDelay is long enough that thread contention here shouldn't matter
+                _expireAfterDate = System.currentTimeMillis() + _evictionDelayInMilliSeconds;
+            }
+        }
+    }
+
+    /**
+     * Builds a {@code MultiThreadedClientServiceCache} with a default executor and cleanup delay.
+     * Used by the builder.
+     *
+     * @param serviceFactory The service factory for creating service handles
+     * @param metricRegistry The metric registry for reporting metrics
+     */
+    MultiThreadedClientServiceCache(MultiThreadedServiceFactory<S> serviceFactory, MetricRegistry metricRegistry) {
+        this(serviceFactory, buildDefaultExecutor(), DEFAULT_EVICTION_DELAY_SECONDS, DEFAULT_CLEANUP_DELAY_SECONDS, metricRegistry);
+    }
+
+    /**
+     * Builds a {@code MultiThreadedClientServiceCache} with configurable eviction and cleanUp delays.
+     *
+     * @param serviceFactory         The service factory for creating service handles
+     * @param executor               The executor for creating the eviction list (cache) cleanup thread
+     * @param evictionDelayInSeconds how long to keep evicted handles around
+     * @param cleanUpDelayInSeconds  how long to wait before scheduled cleanup
+     * @param metricRegistry         The metric registry for reporting metrics
+     */
+    @VisibleForTesting
+    MultiThreadedClientServiceCache(MultiThreadedServiceFactory<S> serviceFactory, ScheduledExecutorService executor,
+                                    int evictionDelayInSeconds, int cleanUpDelayInSeconds, MetricRegistry metricRegistry) {
+        checkNotNull(serviceFactory);
+        checkNotNull(metricRegistry);
+        checkArgument(evictionDelayInSeconds >= 0);
+        checkArgument(cleanUpDelayInSeconds >= 0);
+
+        _serviceFactory = serviceFactory;
+        _cleanupExecutor = executor;
+        _evictionDelayInMilliSeconds = SECONDS.toMillis(evictionDelayInSeconds);
+        _isClosed = false;
+
+        _metrics = Metrics.forInstance(metricRegistry, this, serviceFactory.getServiceName());
+        _registerTimer = _metrics.timer("register-time");
+        _evictionTimer = _metrics.timer("eviction-time");
+        _serviceCounter = _metrics.counter("service-counter");
+
+        _cleanupFuture = _cleanupExecutor.scheduleAtFixedRate(
+                new Runnable() {
+                    @Override
+                    public void run() {
+                        List<HeavyServiceHandle<S>> handlesToDelete = new LinkedList<>();
+                        // Don't synchronize on just 'this', as 'this' is a anonymous inner Runnable class.
+                        // Instead synchronize on our parent class instance of MultiThreadedClientServiceCache so that
+                        // this code will be synchronized with evict() and doRegister().
+                        synchronized (MultiThreadedClientServiceCache.this) {
+                            Map<ServiceEndPoint, HeavyServiceHandle<S>> sourceCopy = Maps.newHashMap(_instancesPerEndpoint);
+                            // Purge evicted instances from the copy-on-write map
+                            for (HeavyServiceHandle<S> handle : _instancesPerEndpoint.values()) {
+                                if (handle.timeToEvict()) {
+                                    handlesToDelete.add(sourceCopy.remove(handle.getEndPoint()));
+                                }
+                            }
+                            _instancesPerEndpoint = sourceCopy;
+                        }
+                        // Outside the synchronization loop, schedule the ServiceHandles for deletion
+                        for (HeavyServiceHandle<S> handle : handlesToDelete) {
+                            destroyService(handle);
+                        }
+                        _serviceCounter.dec(handlesToDelete.size());
+                    }
+                },
+                // In our unit tests we want to set the cleanup timeout to "zero", but executorService
+                // does not like that, so we set it to at least a millisecond.
+                SECONDS.toMillis(cleanUpDelayInSeconds) + 1,
+                SECONDS.toMillis(cleanUpDelayInSeconds) + 1,
+                TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * Mimics the behavior of a cache check in, actually a NO-OP.
+     * <p/>
+     * Since the {@code MultiThreadedClientServiceCache} does not have multiple service handles for an endPoint
+     *
+     * @param handle The service handle that is being checked in.
+     * @throws NullPointerException if the handle is null
+     */
+    @Override
+    public void checkIn(ServiceHandle<S> handle) throws Exception {
+        checkNotNull(handle);
+    }
+
+    /**
+     * Given an ServiceEndpoint return a ServiceHandle.
+     * <p/>
+     * If a ServiceHandle does not exist for the given ServiceEndpoint, this method will
+     * synchronously create one and return it.
+     *
+     * @param endPoint The end point to retrieve the instance of service handle for
+     * @return the service handle
+     * @throws IllegalStateException if the cache is closed
+     * @throws NullPointerException  if endPoint is null
+     */
+    @Override
+    public ServiceHandle<S> checkOut(ServiceEndPoint endPoint) throws Exception {
+        checkNotNull(endPoint);
+        checkState(!_isClosed, "cache is closed");
+        ServiceHandle<S> serviceHandle = _instancesPerEndpoint.get(endPoint);
+        if (serviceHandle == null) {
+            // This is the non-ideal state, as we now have to call a synchronized
+            // method to create the ServiceHandle and update the copy-on-write map.
+            //
+            // Note this can/will happen when new Endpoints are discovered due to the
+            // inherent race conditions in ServicePool and HostDiscovery.
+            return doRegister(endPoint);
+        }
+
+        // Note we are not checking if the serviceHandle has been flagged for Eviction, as
+        //  there are race conditions between checkOut() and ServiceCache.evict().
+        return serviceHandle;
+    }
+
+    /**
+     * Private registration method that is used by checkout() and register().
+     *
+     * @param endPoint the end point
+     * @return the service handle
+     */
+    private ServiceHandle<S> doRegister(ServiceEndPoint endPoint) {
+        checkNotNull(endPoint);
+
+        ServiceHandle<S> toDelete = null;
+        ServiceHandle<S> toReturn;
+
+        synchronized (this) {
+            HeavyServiceHandle<S> existingServiceHandle = _instancesPerEndpoint.get(endPoint);
+            if (existingServiceHandle == null || existingServiceHandle.hasBeenFlaggedForEviction() || existingServiceHandle.isOld()) {
+
+                // If there was not an existingServiceHandle, then make a new one.
+                //
+                // If existingServiceHandle.hasBeenFlaggedForEviction() is true, that means this EndPoint
+                //  has been "evicted" for being "bad" but has recovered before the Eviction timeout
+                //  process has gotten around to cleaning up this serviceHandle.  In this case, we assume
+                //  the "safest" thing to do is to create a new Client for that EndPoint, in case the
+                //  problem was with the "old" client.
+                //
+                // If the existingServiceHandle is "new" don't create a new client object due to the
+                //  race condition in HostDiscovery and ServicePool, which can cause a checkOut() to
+                //  occur before its associated ServiceCache.register().
+                // Thus we want have a short period of time where duplicate "checkouts" and a register
+                //  will not thrash the system creating a series of Client instances.
+                //
+                // _serviceFactory.create(endPoint) is a potentially expensive operation, memory, file handles, etc.
+                // hence we really only want to do it when we have to, preferably via the out-of-band
+                // ServiceCache.register() method, instead of the high traffic checkOut method.
+                S service = _serviceFactory.create(endPoint);
+                _serviceCounter.inc();
+
+                HeavyServiceHandle<S> newServiceHandle = new HeavyServiceHandle<>(service, endPoint);
+
+                // add the newServiceHandle to a new copy of the _instancesPerEndpoint map
+                Map<ServiceEndPoint, HeavyServiceHandle<S>> sourceCopy = Maps.newHashMap(_instancesPerEndpoint);
+                sourceCopy.put(endPoint, newServiceHandle);
+                _instancesPerEndpoint = sourceCopy;
+
+                toDelete = existingServiceHandle;
+                toReturn = newServiceHandle;
+            } else {
+                // The existingServiceHandle was not null, not evicted, and not old, thus we did not recreate it.
+                toReturn = existingServiceHandle;
+            }
+        }
+
+        // Destroy instances outside the synchronization, with the idea being it may be an expensive operation
+        if (toDelete != null) {
+            destroyService(toDelete);
+            _serviceCounter.dec();
+        }
+
+        return toReturn;
+    }
+
+    @Override
+    public void register(ServiceEndPoint endPoint) {
+        checkNotNull(endPoint);
+
+        Timer.Context context = _registerTimer.time();
+        try {
+            doRegister(endPoint);
+        } catch (Exception ex) {
+            LOG.error("Error registering service handle", ex);
+        } finally {
+            context.stop();
+        }
+    }
+
+    @Override
+    public synchronized void evict(ServiceEndPoint endPoint) {
+        checkNotNull(endPoint);
+        Timer.Context context = _evictionTimer.time();
+
+        // This method is synchronized, as even though we are not swapping the copy-on-write map,
+        // we are still modifying its contents a bit.
+        HeavyServiceHandle serviceHandle = _instancesPerEndpoint.get(endPoint);
+        if (serviceHandle != null) {
+            serviceHandle.flagAsEvicted();
+        }
+        context.stop();
+    }
+
+    @Override
+    public synchronized void close() {
+        _isClosed = true;
+
+        for (ServiceHandle<S> serviceHandle : _instancesPerEndpoint.values()) {
+            _serviceFactory.destroy(serviceHandle.getEndPoint(), serviceHandle.getService());
+        }
+        _instancesPerEndpoint = Maps.newHashMap();
+        _cleanupFuture.cancel(false);
+        _cleanupExecutor.shutdownNow();
+        _metrics.close();
+    }
+
+    /**
+     * As these clients are multi threaded single instance, there's always one available
+     *
+     * @param endPoint to find idle instance count
+     * @return 1 if endPoint is registered, 0 otherwise
+     */
+    @Override
+    public int getNumIdleInstances(ServiceEndPoint endPoint) {
+        checkNotNull(endPoint);
+        return _instancesPerEndpoint.containsKey(endPoint) ? 1 : 0;
+    }
+
+    /**
+     * This does not track if an instance is actively being used, however given its
+     * singleton nature but it is safe to assume it is always being used
+     *
+     * @param endPoint to find active instance count
+     * @return 1 if endPoint is registered, 0 otherwise
+     */
+    @Override
+    public int getNumActiveInstances(ServiceEndPoint endPoint) {
+        checkNotNull(endPoint);
+        return _instancesPerEndpoint.containsKey(endPoint) ? 1 : 0;
+    }
+
+    /**
+     * Destroys a service handle quietly, swallows any exception occurred
+     *
+     * @param serviceHandle to destroy
+     */
+    private void destroyService(ServiceHandle<S> serviceHandle) {
+        try {
+            _serviceFactory.destroy(serviceHandle.getEndPoint(), serviceHandle.getService());
+        } catch (Exception e) {
+            // this should not happen, but if it does, swallow the exception and log it
+            LOG.warn("Error destroying serviceHandle", e);
+        }
+    }
+}

--- a/core/src/main/java/com/bazaarvoice/ostrich/pool/ServiceCache.java
+++ b/core/src/main/java/com/bazaarvoice/ostrich/pool/ServiceCache.java
@@ -1,280 +1,75 @@
 package com.bazaarvoice.ostrich.pool;
 
 import com.bazaarvoice.ostrich.ServiceEndPoint;
-import com.bazaarvoice.ostrich.ServiceFactory;
-import com.bazaarvoice.ostrich.exceptions.NoCachedInstancesAvailableException;
-import com.bazaarvoice.ostrich.metrics.Metrics;
-import com.codahale.metrics.MetricRegistry;
-import com.codahale.metrics.RatioGauge;
-import com.codahale.metrics.Timer;
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.MapMaker;
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import org.apache.commons.pool.BaseKeyedPoolableObjectFactory;
-import org.apache.commons.pool.impl.GenericKeyedObjectPool;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
-import java.util.Map;
-import java.util.NoSuchElementException;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
- * A cache for service instances. Useful if there's more than insignificant overhead in creating service connections
- * from a {@link ServiceEndPoint}.  Will spawn one thread (shared by all {@code ServiceCache}s) to handle evictions of
+ * A cache for service instances. Useful if there's more than insignificant
+ * overhead in creating service connections
+ *
+ * @param <S> the type parameter of Service
  */
-class ServiceCache<S> implements Closeable {
-    private static final Logger LOG = LoggerFactory.getLogger(ServiceCache.class);
-    private static final ScheduledExecutorService EVICTION_EXECUTOR = Executors.newScheduledThreadPool(1,
-            new ThreadFactoryBuilder()
-                    .setNameFormat("ServiceCache-EvictionThread-%d")
-                    .setDaemon(true)
-                    .build());
-
-    /** How often to try to evict old service instances. */
-    @VisibleForTesting
-    static final long EVICTION_DURATION_IN_SECONDS = 300;
-
-    private final GenericKeyedObjectPool<ServiceEndPoint, S> _pool;
-    private final AtomicLong _revisionNumber = new AtomicLong();
-    private final Map<ServiceEndPoint, Long> _invalidRevisions = new MapMaker().weakKeys().makeMap();
-    private final Map<ServiceHandle<S>, Long> _checkedOutRevisions = new MapMaker().makeMap();
-    private final Future<?> _evictionFuture;
-    private volatile boolean _isClosed = false;
-    private final Metrics.InstanceMetrics _metrics;
-    private final Timer _loadTimer;
-    private final AtomicLong _requestCount = new AtomicLong();
-    private final AtomicLong _missCount = new AtomicLong();
-    private final AtomicLong _loadSuccessCount = new AtomicLong();
-    private final AtomicLong _loadFailureCount = new AtomicLong();
+public interface ServiceCache<S> extends Closeable {
 
     /**
-     * Builds a basic service cache.
+     * Retrieves a cached service instance for a registered end point. A new service handle is
+     * created and returned for a new end point. Once the checked out instance is no longer in
+     * use, it should be returned by calling {@link #checkIn}. It is recommended that end
+     * points should be registered with the cache with {@link #register} first, however
+     * {@code #checkOut} can internally register a new end point if it's missed due to inherent
+     * race condition between {@code #checkOut} and {@link #register}
      *
-     * @param policy         The configuration for this cache.
-     * @param serviceFactory The factory to fall back to on cache misses.
-     * @param metrics        The metric registry.
+     * @param endPoint The end point to retrieve the instance of service handle for
+     * @return A service handle that contains a cached service instance for the requested end point
+     * @throws Exception if internal error prohibits from creating/returning a handle
      */
-    ServiceCache(ServiceCachingPolicy policy, ServiceFactory<S> serviceFactory, MetricRegistry metrics) {
-        this(policy, serviceFactory, EVICTION_EXECUTOR, metrics);
-    }
+    ServiceHandle<S> checkOut(ServiceEndPoint endPoint) throws Exception;
 
     /**
-     * Builds a basic service cache.
+     * Returns a service instance for an end point to the cache so that it may be used by
+     * others
      *
-     * @param policy         The configuration for this cache.
-     * @param serviceFactory The factory to fall back to on cache misses.
-     * @param executor       The executor to use for checking for idle instances to evict.
+     * @param handle The service handle that is being checked in
      */
-    @VisibleForTesting
-    ServiceCache(ServiceCachingPolicy policy, ServiceFactory<S> serviceFactory, ScheduledExecutorService executor,
-                 MetricRegistry metrics) {
-        checkNotNull(policy);
-        checkNotNull(serviceFactory);
-        checkNotNull(executor);
-
-        String serviceName = serviceFactory.getServiceName();
-        _metrics = Metrics.forInstance(metrics, this, serviceName);
-        _loadTimer = _metrics.timer("load-time");
-
-        _metrics.gauge("cache-hit-ratio", new RatioGauge() {
-            @Override
-            protected Ratio getRatio() {
-                return Ratio.of(_requestCount.get() - _missCount.get(), _requestCount.get());
-            }
-        });
-
-        _metrics.gauge("cache-miss-ratio", new RatioGauge() {
-            @Override
-            protected Ratio getRatio() {
-                return Ratio.of(_missCount.get(), _requestCount.get());
-            }
-        });
-
-        _metrics.gauge("load-success-ratio", new RatioGauge() {
-            @Override
-            protected Ratio getRatio() {
-                return Ratio.of(_loadSuccessCount.get(), _loadSuccessCount.get() + _loadFailureCount.get());
-            }
-        });
-        _metrics.gauge("load-failure-ratio", new RatioGauge() {
-            @Override
-            protected Ratio getRatio() {
-                return Ratio.of(_loadFailureCount.get(), _loadSuccessCount.get() + _loadFailureCount.get());
-            }
-        });
-
-        GenericKeyedObjectPool.Config poolConfig = new GenericKeyedObjectPool.Config();
-
-        // Global configuration
-        poolConfig.maxTotal = policy.getMaxNumServiceInstances();
-        poolConfig.numTestsPerEvictionRun = policy.getMaxNumServiceInstances();
-        poolConfig.minEvictableIdleTimeMillis = policy.getMaxServiceInstanceIdleTime(TimeUnit.MILLISECONDS);
-
-        switch (policy.getCacheExhaustionAction()) {
-            case FAIL:
-                poolConfig.whenExhaustedAction = GenericKeyedObjectPool.WHEN_EXHAUSTED_FAIL;
-                break;
-            case GROW:
-                poolConfig.whenExhaustedAction = GenericKeyedObjectPool.WHEN_EXHAUSTED_GROW;
-                break;
-            case WAIT:
-                poolConfig.whenExhaustedAction = GenericKeyedObjectPool.WHEN_EXHAUSTED_BLOCK;
-                break;
-        }
-
-        // Per end point configuration
-        poolConfig.maxActive = policy.getMaxNumServiceInstancesPerEndPoint();
-        poolConfig.maxIdle = policy.getMaxNumServiceInstancesPerEndPoint();
-
-        // Make sure all instances in the pool are checked for staleness during eviction runs.
-        poolConfig.numTestsPerEvictionRun = policy.getMaxNumServiceInstances();
-
-        _pool = new GenericKeyedObjectPool<>(new PoolServiceFactory<>(serviceFactory), poolConfig);
-
-        // Don't schedule eviction if not caching or not expiring stale instances.
-        _evictionFuture = (policy.getMaxNumServiceInstances() != 0)
-                || (policy.getMaxNumServiceInstancesPerEndPoint() != 0)
-                || (policy.getMaxServiceInstanceIdleTime(TimeUnit.MILLISECONDS) > 0)
-                ? executor.scheduleAtFixedRate(new Runnable() {
-                      @Override
-                      public void run() {
-                          try {
-                              _pool.evict();
-                          } catch (Exception e) {
-                              // Should never happen, but log just in case. Swallow exception so thread doesn't die.
-                              LOG.error("ServiceCache eviction run failed.", e);
-                          }
-                      }
-                  }, EVICTION_DURATION_IN_SECONDS, EVICTION_DURATION_IN_SECONDS, TimeUnit.SECONDS)
-                : null;
-    }
-
-    @VisibleForTesting
-    GenericKeyedObjectPool<ServiceEndPoint, S> getPool() {
-        return _pool;
-    }
+    void checkIn(ServiceHandle<S> handle) throws Exception;
 
     /**
-     * Retrieves a cached service instance for an end point that is not currently checked out.  If no idle cached
-     * instance is available and the cache is not full, a new one will be created, added to the cache, and then checked
-     * out.  Once the checked out instance is no longer in use, it should be returned by calling {@link #checkIn}.
-     *
-     * @param endPoint The end point to retrieve a cached service instance for.
-     * @return A service handle that contains a cached service instance for the requested end point.
-     * @throws NoCachedInstancesAvailableException If the cache has reached total maximum capacity, or maximum capacity
-     *         for the requested end point, and no connections that aren't already checked out are available.
+     * @param endPoint to find idle instance count for
+     * @return number of registered service handles for the given endPoint
      */
-    public ServiceHandle<S> checkOut(ServiceEndPoint endPoint) throws Exception {
-        checkNotNull(endPoint);
-        _requestCount.incrementAndGet();
-
-        try {
-            long revision = _revisionNumber.incrementAndGet();
-            S service = _pool.borrowObject(endPoint);
-            ServiceHandle<S> handle = new ServiceHandle<>(service, endPoint);
-
-            // Remember the revision that we've checked this service out on in case we need to invalidate it later
-            _checkedOutRevisions.put(handle, revision);
-
-            return handle;
-        } catch (NoSuchElementException e) {
-            _missCount.incrementAndGet();
-
-            // This will happen if there are no available connections and there is no room for a new one,
-            // or if a newly created connection is not valid.
-            throw new NoCachedInstancesAvailableException();
-        }
-    }
+    int getNumIdleInstances(ServiceEndPoint endPoint);
 
     /**
-     * Returns a service instance for an end point to the cache so that it may be used by other users.
-     *
-     * @param handle The service handle that is being checked in.
-     * @throws Exception Never.
+     * @param endPoint to find active instance count for
+     * @return number of active service handles for a given endPoint
      */
-    public void checkIn(ServiceHandle<S> handle) throws Exception {
-        checkNotNull(handle);
+    int getNumActiveInstances(ServiceEndPoint endPoint);
 
-        S service = handle.getService();
-        ServiceEndPoint endPoint = handle.getEndPoint();
-
-        // Figure out if we should check this revision in.  If it was created before the last known invalid revision
-        // for this particular end point, or the cache is closed, then we shouldn't check it in.
-        Long invalidRevision = _invalidRevisions.get(endPoint);
-        Long serviceRevision = _checkedOutRevisions.remove(handle);
-
-        if (_isClosed || (invalidRevision != null && serviceRevision < invalidRevision)) {
-            _pool.invalidateObject(endPoint, service);
-        } else {
-            _pool.returnObject(endPoint, service);
-        }
-    }
-
-    public int getNumIdleInstances(ServiceEndPoint endPoint) {
-        checkNotNull(endPoint);
-        return _pool.getNumIdle(endPoint);
-    }
-
-    public int getNumActiveInstances(ServiceEndPoint endPoint) {
-        checkNotNull(endPoint);
-        return _pool.getNumActive(endPoint);
-    }
-
+    /**
+     * Closes the cache
+     */
     @Override
-    public void close() {
-        _isClosed = true;
+    void close();
 
-        if (_evictionFuture != null) {
-            _evictionFuture.cancel(false);
-        }
+    /**
+     * As new end points gets added to the service pool, as part of initialization
+     * this method allows the pool to register that endpoint to the cache. Ideally
+     * this allows the cache to have a service handle ready for checkOut before
+     * the first request comes in.
+     *
+     * This is particularly helpful for heavyweight clients that are expensive to
+     * create, thus allows to pre-load the cache with available endPoints eagerly
+     * instead of lazy loading during {@link #checkOut}
+     *
+     * @param endPoint to register with the cache
+     */
+    void register(ServiceEndPoint endPoint);
 
-        _pool.clear();
-        _metrics.close();
-    }
-
-    public void evict(ServiceEndPoint endPoint) {
-        checkNotNull(endPoint);
-
-        // Mark all service instances created prior to now as invalid so that we don't inadvertently check them back in
-        _invalidRevisions.put(endPoint, _revisionNumber.incrementAndGet());
-        _pool.clear(endPoint);
-    }
-
-    private class PoolServiceFactory<S> extends BaseKeyedPoolableObjectFactory<ServiceEndPoint, S> {
-        private final ServiceFactory<S> _serviceFactory;
-
-        public PoolServiceFactory(ServiceFactory<S> serviceFactory) {
-            _serviceFactory = serviceFactory;
-        }
-
-        @Override
-        public S makeObject(final ServiceEndPoint endPoint) throws Exception {
-            _missCount.incrementAndGet();
-
-            Timer.Context timer = _loadTimer.time();
-            try {
-                S service = _serviceFactory.create(endPoint);
-                _loadSuccessCount.incrementAndGet();
-                return service;
-            } catch (Exception e) {
-                _loadFailureCount.incrementAndGet();
-                throw e;
-            } finally {
-                timer.stop();
-            }
-        }
-
-        @Override
-        public void destroyObject(ServiceEndPoint endPoint, S service) throws Exception {
-            _serviceFactory.destroy(endPoint, service);
-        }
-    }
+    /**
+     * Evicts an endPoint from the cache
+     *
+     * @param endPoint to evict from the cache
+     */
+    void evict(ServiceEndPoint endPoint);
 }

--- a/core/src/main/java/com/bazaarvoice/ostrich/pool/ServiceCacheBuilder.java
+++ b/core/src/main/java/com/bazaarvoice/ostrich/pool/ServiceCacheBuilder.java
@@ -1,0 +1,57 @@
+package com.bazaarvoice.ostrich.pool;
+
+import com.bazaarvoice.ostrich.MultiThreadedServiceFactory;
+import com.bazaarvoice.ostrich.ServiceFactory;
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class ServiceCacheBuilder<S> {
+
+    private ServiceCachingPolicy _cachingPolicy;
+    private ServiceFactory<S> _serviceFactory;
+    private MetricRegistry _metricRegistry;
+
+    public ServiceCacheBuilder<S> withCachingPolicy(ServiceCachingPolicy cachingPolicy) {
+        _cachingPolicy = cachingPolicy;
+        return this;
+    }
+
+    public ServiceCacheBuilder<S> withServiceFactory(ServiceFactory<S> serviceFactory) {
+        _serviceFactory = serviceFactory;
+        return this;
+    }
+
+    public ServiceCacheBuilder<S> withMetricRegistry(MetricRegistry metricRegistry) {
+        _metricRegistry = metricRegistry;
+        return this;
+    }
+
+    public ServiceCache<S> build() {
+        checkNotNull(_cachingPolicy, "cachingPolicy");
+        if (_cachingPolicy.useMultiThreadedClientPolicy()) {
+            checkNotNull(_serviceFactory, "serviceFactory");
+            checkArgument((_serviceFactory instanceof MultiThreadedServiceFactory), "Please implement MultiThreadedServiceFactory to construct MultiThreadedClientServiceCache");
+            return new MultiThreadedClientServiceCache<>((MultiThreadedServiceFactory<S>) _serviceFactory, _metricRegistry);
+        }
+        else {
+            checkNotNull(_serviceFactory, "serviceFactory");
+            checkNotNull(_metricRegistry, "metricRegistry");
+            return new SingleThreadedClientServiceCache<>(_cachingPolicy, _serviceFactory, _metricRegistry);
+        }
+    }
+
+    /**
+     * This ensures the {@link java.util.concurrent.ScheduledExecutorService} in not loaded onto jvm
+     * until the class is loaded by explicitly calling the constructor.
+     */
+    public static ScheduledExecutorService buildDefaultExecutor() {
+        return Executors.newScheduledThreadPool(1,
+                new ThreadFactoryBuilder().setNameFormat("ServiceCache-CleanupThread-%d").setDaemon(true).build());
+    }
+}

--- a/core/src/main/java/com/bazaarvoice/ostrich/pool/ServiceCachingPolicy.java
+++ b/core/src/main/java/com/bazaarvoice/ostrich/pool/ServiceCachingPolicy.java
@@ -51,4 +51,13 @@ public interface ServiceCachingPolicy {
         /** Wait until an instance is returned to the cache when at the limit of the number of allowed instances. */
         WAIT
     }
+
+    /**
+     * This defaults to false, i.e. the default policy is to support a ServiceCache of single threaded clients.
+     *
+     * If this is set to true, all other params are ignored, and their getters throws unsupported operation exception
+     *
+     * @return true if policy is intended for multi threaded clients
+     */
+    boolean useMultiThreadedClientPolicy();
 }

--- a/core/src/main/java/com/bazaarvoice/ostrich/pool/ServiceCachingPolicyBuilder.java
+++ b/core/src/main/java/com/bazaarvoice/ostrich/pool/ServiceCachingPolicyBuilder.java
@@ -13,6 +13,49 @@ public class ServiceCachingPolicyBuilder {
             .withCacheExhaustionAction(ExhaustionAction.GROW)
             .build();
 
+    /**
+     * Creates a ServiceCachingPolicy configured for multi threaded client strategy,
+     * the {@link com.bazaarvoice.ostrich.pool.MultiThreadedClientServiceCache}
+     * <p/>
+     * This policy returns true for useMultiThreadedClientPolicy() but throws
+     * {@link java.lang.UnsupportedOperationException} for everything else
+     *
+     */
+    private static final ServiceCachingPolicy DEFAULT_MULTI_THREADED_CLIENTS_POLICY = new ServiceCachingPolicy() {
+        @Override
+        public int getMaxNumServiceInstances() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public int getMaxNumServiceInstancesPerEndPoint() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public long getMaxServiceInstanceIdleTime(TimeUnit unit) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ExhaustionAction getCacheExhaustionAction() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean useMultiThreadedClientPolicy() {
+            return true;
+        }
+    };
+
+    /**
+     *
+     * @return ServiceCachingPolicy configured to build a {@code MultiThreadedClientServiceCache}
+     */
+    public static ServiceCachingPolicy getMultiThreadedClientPolicy() {
+        return DEFAULT_MULTI_THREADED_CLIENTS_POLICY;
+    }
+
     private int _maxNumServiceInstances = -1;
     private int _maxNumServiceInstancesPerEndPoint = -1;
     private long _maxServiceInstanceIdleTimeNanos;
@@ -110,6 +153,11 @@ public class ServiceCachingPolicyBuilder {
             @Override
             public ExhaustionAction getCacheExhaustionAction() {
                 return cacheExhaustionAction;
+            }
+
+            @Override
+            public boolean useMultiThreadedClientPolicy() {
+                return false;
             }
         };
     }

--- a/core/src/main/java/com/bazaarvoice/ostrich/pool/ServiceHandle.java
+++ b/core/src/main/java/com/bazaarvoice/ostrich/pool/ServiceHandle.java
@@ -17,7 +17,7 @@ class ServiceHandle<S> {
         return _service;
     }
 
-    ServiceEndPoint getEndPoint() {
+    public ServiceEndPoint getEndPoint() {
         return _endPoint;
     }
 }

--- a/core/src/main/java/com/bazaarvoice/ostrich/pool/SingleThreadedClientServiceCache.java
+++ b/core/src/main/java/com/bazaarvoice/ostrich/pool/SingleThreadedClientServiceCache.java
@@ -1,0 +1,288 @@
+package com.bazaarvoice.ostrich.pool;
+
+import com.bazaarvoice.ostrich.ServiceEndPoint;
+import com.bazaarvoice.ostrich.ServiceFactory;
+import com.bazaarvoice.ostrich.exceptions.NoCachedInstancesAvailableException;
+import com.bazaarvoice.ostrich.metrics.Metrics;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.RatioGauge;
+import com.codahale.metrics.Timer;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.MapMaker;
+import org.apache.commons.pool.BaseKeyedPoolableObjectFactory;
+import org.apache.commons.pool.impl.GenericKeyedObjectPool;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static com.bazaarvoice.ostrich.pool.ServiceCacheBuilder.buildDefaultExecutor;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * A cache for service instances. Useful if there's more than insignificant overhead in creating service connections
+ * from a {@link com.bazaarvoice.ostrich.ServiceEndPoint}.  Will spawn one thread (shared by all
+ * {@link com.bazaarvoice.ostrich.pool.ServiceCache}s) to handle evictions of
+ */
+class SingleThreadedClientServiceCache<S> implements ServiceCache<S> {
+    private static final Logger LOG = LoggerFactory.getLogger(SingleThreadedClientServiceCache.class);
+
+    /** How often to try to evict old service instances. */
+    @VisibleForTesting
+    static final long EVICTION_DURATION_IN_SECONDS = 300;
+
+    private final GenericKeyedObjectPool<ServiceEndPoint, S> _pool;
+    private final AtomicLong _revisionNumber = new AtomicLong();
+    private final Map<ServiceEndPoint, Long> _invalidRevisions = new MapMaker().weakKeys().makeMap();
+    private final Map<ServiceHandle<S>, Long> _checkedOutRevisions = new MapMaker().makeMap();
+    private final Future<?> _evictionFuture;
+    private volatile boolean _isClosed = false;
+    private final Metrics.InstanceMetrics _metrics;
+    private final Timer _loadTimer;
+    private final AtomicLong _requestCount = new AtomicLong();
+    private final AtomicLong _missCount = new AtomicLong();
+    private final AtomicLong _loadSuccessCount = new AtomicLong();
+    private final AtomicLong _loadFailureCount = new AtomicLong();
+
+    /**
+     * Builds a basic service cache.
+     *
+     * @param policy         The configuration for this cache.
+     * @param serviceFactory The factory to fall back to on cache misses.
+     * @param metrics        The metric registry.
+     */
+    SingleThreadedClientServiceCache(ServiceCachingPolicy policy, ServiceFactory<S> serviceFactory, MetricRegistry metrics) {
+        this(policy, serviceFactory, buildDefaultExecutor(), metrics);
+    }
+
+    /**
+     * Builds a basic service cache.
+     *
+     * @param policy         The configuration for this cache.
+     * @param serviceFactory The factory to fall back to on cache misses.
+     * @param executor       The executor to use for checking for idle instances to evict.
+     */
+    @VisibleForTesting
+    SingleThreadedClientServiceCache(ServiceCachingPolicy policy, ServiceFactory<S> serviceFactory, ScheduledExecutorService executor,
+                                     MetricRegistry metrics) {
+        checkNotNull(policy);
+        checkNotNull(serviceFactory);
+        checkNotNull(executor);
+
+        String serviceName = serviceFactory.getServiceName();
+        _metrics = Metrics.forInstance(metrics, this, serviceName);
+        _loadTimer = _metrics.timer("load-time");
+
+        _metrics.gauge("cache-hit-ratio", new RatioGauge() {
+            @Override
+            protected Ratio getRatio() {
+                return Ratio.of(_requestCount.get() - _missCount.get(), _requestCount.get());
+            }
+        });
+
+        _metrics.gauge("cache-miss-ratio", new RatioGauge() {
+            @Override
+            protected Ratio getRatio() {
+                return Ratio.of(_missCount.get(), _requestCount.get());
+            }
+        });
+
+        _metrics.gauge("load-success-ratio", new RatioGauge() {
+            @Override
+            protected Ratio getRatio() {
+                return Ratio.of(_loadSuccessCount.get(), _loadSuccessCount.get() + _loadFailureCount.get());
+            }
+        });
+        _metrics.gauge("load-failure-ratio", new RatioGauge() {
+            @Override
+            protected Ratio getRatio() {
+                return Ratio.of(_loadFailureCount.get(), _loadSuccessCount.get() + _loadFailureCount.get());
+            }
+        });
+
+        GenericKeyedObjectPool.Config poolConfig = new GenericKeyedObjectPool.Config();
+
+        // Global configuration
+        poolConfig.maxTotal = policy.getMaxNumServiceInstances();
+        poolConfig.numTestsPerEvictionRun = policy.getMaxNumServiceInstances();
+        poolConfig.minEvictableIdleTimeMillis = policy.getMaxServiceInstanceIdleTime(TimeUnit.MILLISECONDS);
+
+        switch (policy.getCacheExhaustionAction()) {
+            case FAIL:
+                poolConfig.whenExhaustedAction = GenericKeyedObjectPool.WHEN_EXHAUSTED_FAIL;
+                break;
+            case GROW:
+                poolConfig.whenExhaustedAction = GenericKeyedObjectPool.WHEN_EXHAUSTED_GROW;
+                break;
+            case WAIT:
+                poolConfig.whenExhaustedAction = GenericKeyedObjectPool.WHEN_EXHAUSTED_BLOCK;
+                break;
+        }
+
+        // Per end point configuration
+        poolConfig.maxActive = policy.getMaxNumServiceInstancesPerEndPoint();
+        poolConfig.maxIdle = policy.getMaxNumServiceInstancesPerEndPoint();
+
+        // Make sure all instances in the pool are checked for staleness during eviction runs.
+        poolConfig.numTestsPerEvictionRun = policy.getMaxNumServiceInstances();
+
+        _pool = new GenericKeyedObjectPool<>(new PoolServiceFactory<>(serviceFactory), poolConfig);
+
+        // Don't schedule eviction if not caching or not expiring stale instances.
+        _evictionFuture = (policy.getMaxNumServiceInstances() != 0)
+                || (policy.getMaxNumServiceInstancesPerEndPoint() != 0)
+                || (policy.getMaxServiceInstanceIdleTime(TimeUnit.MILLISECONDS) > 0)
+                ? executor.scheduleAtFixedRate(new Runnable() {
+                      @Override
+                      public void run() {
+                          try {
+                              _pool.evict();
+                          } catch (Exception e) {
+                              // Should never happen, but log just in case. Swallow exception so thread doesn't die.
+                              LOG.error("ServiceCache eviction run failed.", e);
+                          }
+                      }
+                  }, EVICTION_DURATION_IN_SECONDS, EVICTION_DURATION_IN_SECONDS, TimeUnit.SECONDS)
+                : null;
+    }
+
+    @VisibleForTesting
+    GenericKeyedObjectPool<ServiceEndPoint, S> getPool() {
+        return _pool;
+    }
+
+    /**
+     * Retrieves a cached service instance for an end point that is not currently checked out.  If no idle cached
+     * instance is available and the cache is not full, a new one will be created, added to the cache, and then checked
+     * out.  Once the checked out instance is no longer in use, it should be returned by calling {@link #checkIn}.
+     *
+     * @param endPoint The end point to retrieve a cached service instance for.
+     * @return A service handle that contains a cached service instance for the requested end point.
+     * @throws NoCachedInstancesAvailableException If the cache has reached total maximum capacity, or maximum capacity
+     *         for the requested end point, and no connections that aren't already checked out are available.
+     */
+    public ServiceHandle<S> checkOut(ServiceEndPoint endPoint) throws Exception {
+        checkNotNull(endPoint);
+        _requestCount.incrementAndGet();
+
+        try {
+            long revision = _revisionNumber.incrementAndGet();
+            S service = _pool.borrowObject(endPoint);
+            ServiceHandle<S> handle = new ServiceHandle<>(service, endPoint);
+
+            // Remember the revision that we've checked this service out on in case we need to invalidate it later
+            _checkedOutRevisions.put(handle, revision);
+
+            return handle;
+        } catch (NoSuchElementException e) {
+            _missCount.incrementAndGet();
+
+            // This will happen if there are no available connections and there is no room for a new one,
+            // or if a newly created connection is not valid.
+            throw new NoCachedInstancesAvailableException();
+        }
+    }
+
+    /**
+     * Returns a service instance for an end point to the cache so that it may be used by other users.
+     *
+     * @param handle The service handle that is being checked in.
+     * @throws Exception Never.
+     */
+    @Override
+    public void checkIn(ServiceHandle<S> handle) throws Exception {
+        checkNotNull(handle);
+
+        S service = handle.getService();
+        ServiceEndPoint endPoint = handle.getEndPoint();
+
+        // Figure out if we should check this revision in.  If it was created before the last known invalid revision
+        // for this particular end point, or the cache is closed, then we shouldn't check it in.
+        Long invalidRevision = _invalidRevisions.get(endPoint);
+        Long serviceRevision = _checkedOutRevisions.remove(handle);
+
+        if (_isClosed || (invalidRevision != null && serviceRevision < invalidRevision)) {
+            _pool.invalidateObject(endPoint, service);
+        } else {
+            _pool.returnObject(endPoint, service);
+        }
+    }
+
+    @Override
+    public int getNumIdleInstances(ServiceEndPoint endPoint) {
+        checkNotNull(endPoint);
+        return _pool.getNumIdle(endPoint);
+    }
+
+    @Override
+    public int getNumActiveInstances(ServiceEndPoint endPoint) {
+        checkNotNull(endPoint);
+        return _pool.getNumActive(endPoint);
+    }
+
+    @Override
+    public void close() {
+        _isClosed = true;
+
+        if (_evictionFuture != null) {
+            _evictionFuture.cancel(false);
+        }
+
+        try {
+            _pool.close();
+        }
+        catch(Exception e) {
+            LOG.error("Error closing pool", e);
+        }
+        _metrics.close();
+    }
+
+    @Override
+    public void register(ServiceEndPoint endPoint) {
+        // implementation of the ServiceCache creates clients lazily
+    }
+
+    @Override
+    public void evict(ServiceEndPoint endPoint) {
+        checkNotNull(endPoint);
+
+        // Mark all service instances created prior to now as invalid so that we don't inadvertently check them back in
+        _invalidRevisions.put(endPoint, _revisionNumber.incrementAndGet());
+        _pool.clear(endPoint);
+    }
+
+    private class PoolServiceFactory<S> extends BaseKeyedPoolableObjectFactory<ServiceEndPoint, S> {
+        private final ServiceFactory<S> _serviceFactory;
+
+        public PoolServiceFactory(ServiceFactory<S> serviceFactory) {
+            _serviceFactory = serviceFactory;
+        }
+
+        @Override
+        public S makeObject(final ServiceEndPoint endPoint) throws Exception {
+            _missCount.incrementAndGet();
+
+            Timer.Context timer = _loadTimer.time();
+            try {
+                S service = _serviceFactory.create(endPoint);
+                _loadSuccessCount.incrementAndGet();
+                return service;
+            } catch (Exception e) {
+                _loadFailureCount.incrementAndGet();
+                throw e;
+            } finally {
+                timer.stop();
+            }
+        }
+
+        @Override
+        public void destroyObject(ServiceEndPoint endPoint, S service) throws Exception {
+            _serviceFactory.destroy(endPoint, service);
+        }
+    }
+}

--- a/core/src/test/java/com/bazaarvoice/ostrich/pool/MultiThreadedClientServiceCacheTest.java
+++ b/core/src/test/java/com/bazaarvoice/ostrich/pool/MultiThreadedClientServiceCacheTest.java
@@ -1,0 +1,320 @@
+package com.bazaarvoice.ostrich.pool;
+
+import com.bazaarvoice.ostrich.MultiThreadedServiceFactory;
+import com.bazaarvoice.ostrich.ServiceEndPoint;
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.collect.Lists;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class MultiThreadedClientServiceCacheTest {
+    private ServiceEndPoint _endPoint;
+    private MultiThreadedServiceFactory<Service> _factory;
+    private List<MultiThreadedClientServiceCache<?>> _caches = Lists.newArrayList();
+    private MetricRegistry _metricRegistry = new MetricRegistry();
+
+    @SuppressWarnings ("unchecked")
+    @Before
+    public void setup() {
+        _factory = mock(MultiThreadedServiceFactory.class);
+        when(_factory.getServiceName()).thenReturn(Service.class.getSimpleName());
+        when(_factory.create(any(ServiceEndPoint.class))).thenAnswer(new Answer<Service>() {
+            @Override
+            public Service answer(InvocationOnMock invocation)
+                    throws Throwable {
+                return mock(Service.class);
+            }
+        });
+        _endPoint = newEndPoint("id", "name");
+    }
+
+    @After
+    public void teardown() {
+        for (MultiThreadedClientServiceCache<?> cache : _caches) {
+            cache.close();
+        }
+    }
+
+    @Test (expected = NullPointerException.class)
+    public void testCheckOutFromNullEndPoint()
+            throws Exception {
+        newCache().checkOut(null);
+    }
+
+    @Test (expected = NullPointerException.class)
+    public void testCheckInNullHandle()
+            throws Exception {
+        newCache().checkIn(null);
+    }
+
+    @Test (expected = NullPointerException.class)
+    public void testCheckInToNullEndPoint()
+            throws Exception {
+        Service service = mock(Service.class);
+        ServiceHandle<Service> handle = new ServiceHandle<>(service, null);
+        newCache().checkIn(handle);
+    }
+
+    @Test (expected = NullPointerException.class)
+    public void testCheckInNullServiceInstance()
+            throws Exception {
+        ServiceHandle<Service> handle = new ServiceHandle<>(null, _endPoint);
+        newCache().checkIn(handle);
+    }
+
+    @Test (expected = NullPointerException.class)
+    public void testEvictNullEndPoint() {
+        newCache().evict(null);
+    }
+
+    @Test
+    public void testFactoryExceptionIsPropagated() {
+        NullPointerException exception = mock(NullPointerException.class);
+        when(_factory.create(any(ServiceEndPoint.class))).thenThrow(exception);
+
+        try {
+            newCache().checkOut(_endPoint);
+            fail();
+        } catch (Exception caught) {
+            assertSame(exception, caught);
+        }
+    }
+
+    @Test
+    public void testServiceInstancesAreReused()
+            throws Exception {
+        Service service = mock(Service.class);
+        when(_factory.create(any(ServiceEndPoint.class))).thenReturn(service);
+
+        MultiThreadedClientServiceCache<Service> cache = newCache();
+        ServiceHandle<Service> handle1 = cache.checkOut(_endPoint);
+        ServiceHandle<Service> handle2 = cache.checkOut(_endPoint);
+        ServiceHandle<Service> handle3 = cache.checkOut(_endPoint);
+        ServiceHandle<Service> handle4 = cache.checkOut(_endPoint);
+
+
+        assertSame(service, handle1.getService());
+        assertSame(service, handle2.getService());
+        assertSame(service, handle3.getService());
+        assertSame(service, handle4.getService());
+
+        assertEquals(1, cache.getNumActiveInstances(_endPoint));
+        assertEquals(1, cache.getNumIdleInstances(_endPoint));
+    }
+
+    @Test
+    public void testRegisterCheckOutEvict()
+            throws Exception {
+        Service service = mock(Service.class);
+        when(_factory.create(any(ServiceEndPoint.class))).thenReturn(service);
+
+        MultiThreadedClientServiceCache<Service> cache = newCache(0);
+
+        cache.register(_endPoint);
+        assertEquals(1, cache.getNumActiveInstances(_endPoint));
+        assertEquals(1, cache.getNumIdleInstances(_endPoint));
+
+        ServiceHandle<Service> handle = cache.checkOut(_endPoint);
+        assertSame(service, handle.getService());
+        assertEquals(1, cache.getNumActiveInstances(_endPoint));
+        assertEquals(1, cache.getNumIdleInstances(_endPoint));
+
+        cache.evict(_endPoint);
+        verify(_factory, timeout(100).times(1)).destroy(_endPoint, handle.getService());
+        assertEquals(0, cache.getNumActiveInstances(_endPoint));
+        assertEquals(0, cache.getNumIdleInstances(_endPoint));
+    }
+
+    @Test
+    public void testCheckOutRegisterEvict()
+            throws Exception {
+        Service service = mock(Service.class);
+        when(_factory.create(any(ServiceEndPoint.class))).thenReturn(service);
+
+        MultiThreadedClientServiceCache<Service> cache = newCache(0);
+
+        ServiceHandle<Service> handle = cache.checkOut(_endPoint);
+        assertSame(service, handle.getService());
+        assertEquals(1, cache.getNumActiveInstances(_endPoint));
+        assertEquals(1, cache.getNumIdleInstances(_endPoint));
+
+        cache.register(_endPoint);
+        assertEquals(1, cache.getNumActiveInstances(_endPoint));
+        assertEquals(1, cache.getNumIdleInstances(_endPoint));
+
+        cache.evict(_endPoint);
+        verify(_factory, timeout(100).times(1)).destroy(_endPoint, handle.getService());
+        assertEquals(0, cache.getNumActiveInstances(_endPoint));
+        assertEquals(0, cache.getNumIdleInstances(_endPoint));
+    }
+
+    @Test
+    public void testCheckOutEvictCheckOut()
+            throws Exception {
+        Service service = mock(Service.class);
+        when(_factory.create(any(ServiceEndPoint.class))).thenReturn(service);
+
+        MultiThreadedClientServiceCache<Service> cache = newCache(0);
+
+        ServiceHandle<Service> handle1 = cache.checkOut(_endPoint);
+        assertSame(service, handle1.getService());
+        assertEquals(1, cache.getNumActiveInstances(_endPoint));
+        assertEquals(1, cache.getNumIdleInstances(_endPoint));
+
+        cache.evict(_endPoint);
+        verify(_factory, timeout(100).times(1)).destroy(_endPoint, handle1.getService());
+        assertEquals(0, cache.getNumActiveInstances(_endPoint));
+        assertEquals(0, cache.getNumIdleInstances(_endPoint));
+
+        ServiceHandle<Service> handle2 = cache.checkOut(_endPoint);
+        assertSame(service, handle2.getService());
+        assertEquals(1, cache.getNumActiveInstances(_endPoint));
+        assertEquals(1, cache.getNumIdleInstances(_endPoint));
+
+        assertNotSame(handle1, handle2);
+    }
+
+    @Test
+    public void testEvictedEndPointDestroyedManualEviction()
+            throws Exception {
+        MultiThreadedClientServiceCache<Service> cache = newCache(0);
+        ServiceHandle<Service> handle = cache.checkOut(_endPoint);
+        cache.checkIn(handle);
+        cache.evict(_endPoint);
+
+        verify(_factory, timeout(100).times(1)).destroy(_endPoint, handle.getService());
+    }
+
+    @Test
+    public void testEvictedEndPointWhileServiceInstanceCheckedOut()
+            throws Exception {
+        Service validService = mock(Service.class);
+        ServiceEndPoint validEndPoint = newEndPoint("valid", "name");
+        when(_factory.create(validEndPoint)).thenReturn(validService);
+
+        Service invalidService = mock(Service.class);
+        ServiceEndPoint invalidEndPoint = newEndPoint("invalid", "name");
+        when(_factory.create(invalidEndPoint)).thenReturn(invalidService);
+
+        MultiThreadedClientServiceCache<Service> cache = newCache(0);
+        cache.register(invalidEndPoint);
+        cache.register(validEndPoint);
+
+        ServiceHandle<Service> invalidHandle = cache.checkOut(invalidEndPoint);
+        ServiceHandle<Service> validHandle = cache.checkOut(validEndPoint);
+
+        cache.evict(invalidEndPoint);
+
+        cache.checkIn(invalidHandle);
+        cache.checkIn(validHandle);
+
+        verify(_factory, timeout(100).times(1)).destroy(invalidEndPoint, invalidService);
+        verify(_factory, never()).destroy(validEndPoint, validService);
+    }
+
+    @Test
+    public void testEvictedEndPointWhileDuplicateServiceInstancesCheckedOut()
+            throws Exception {
+        Service service = mock(Service.class);
+        when(_factory.create(any(ServiceEndPoint.class))).thenReturn(service);
+
+        MultiThreadedClientServiceCache<Service> cache = newCache(0);
+
+        ServiceHandle<Service> handle1 = cache.checkOut(_endPoint);
+        ServiceHandle<Service> handle2 = cache.checkOut(_endPoint);
+
+        cache.evict(_endPoint);
+
+        cache.checkIn(handle1);
+        cache.checkIn(handle2);
+
+        assertSame(service, handle1.getService());
+        assertSame(service, handle2.getService());
+        verify(_factory, timeout(100).times(1)).destroy(_endPoint, service);
+    }
+
+    @Test (expected = NullPointerException.class)
+    public void testNumIdleNullEndPoint() {
+        MultiThreadedClientServiceCache<Service> cache = newCache();
+        cache.getNumIdleInstances(null);
+    }
+
+    @Test (expected = NullPointerException.class)
+    public void testNumActiveNullEndPoint() {
+        MultiThreadedClientServiceCache<Service> cache = newCache();
+        cache.getNumActiveInstances(null);
+    }
+
+    @Test
+    public void testNumActiveInstances()
+            throws Exception {
+        MultiThreadedClientServiceCache<Service> cache = newCache();
+        cache.register(_endPoint);
+        assertEquals(1, cache.getNumActiveInstances(_endPoint));
+        assertEquals(0, cache.getNumActiveInstances(newEndPoint("new", "endPoint")));
+    }
+
+    @Test
+    public void testNumIdleInstances()
+            throws Exception {
+        MultiThreadedClientServiceCache<Service> cache = newCache();
+        cache.register(_endPoint);
+        assertEquals(1, cache.getNumIdleInstances(_endPoint));
+        assertEquals(0, cache.getNumActiveInstances(newEndPoint("new", "endPoint")));
+    }
+
+    @Test
+    public void testCloseDestroysCachedInstances()
+            throws Exception {
+        MultiThreadedClientServiceCache<Service> cache = newCache();
+        ServiceHandle<Service> handle = cache.checkOut(_endPoint);
+        cache.checkIn(handle);
+        cache.close();
+
+        verify(_factory).destroy(_endPoint, handle.getService());
+    }
+
+
+    @Test
+    public void testMultipleClose() {
+        MultiThreadedClientServiceCache<Service> cache = newCache();
+        cache.close();
+        cache.close();
+    }
+
+    private MultiThreadedClientServiceCache<Service> newCache() {
+        return newCache(1);
+    }
+
+    private MultiThreadedClientServiceCache<Service> newCache(int ttl) {
+        MultiThreadedClientServiceCache<Service> cache = new MultiThreadedClientServiceCache<>(_factory, ServiceCacheBuilder.buildDefaultExecutor(), ttl, ttl, _metricRegistry);
+        _caches.add(cache);
+        return cache;
+    }
+
+    private ServiceEndPoint newEndPoint(String id, String name) {
+        ServiceEndPoint endPoint = mock(ServiceEndPoint.class);
+        when(endPoint.getId()).thenReturn(id);
+        when(endPoint.getServiceName()).thenReturn(name);
+        when(endPoint.getPayload()).thenReturn("");
+        return endPoint;
+    }
+
+    public static interface Service {
+    }
+}

--- a/core/src/test/java/com/bazaarvoice/ostrich/pool/PoolWithMultiThreadedCacheTest.java
+++ b/core/src/test/java/com/bazaarvoice/ostrich/pool/PoolWithMultiThreadedCacheTest.java
@@ -1,0 +1,23 @@
+package com.bazaarvoice.ostrich.pool;
+
+import com.bazaarvoice.ostrich.MultiThreadedServiceFactory;
+import com.bazaarvoice.ostrich.ServiceFactory;
+
+import static org.mockito.Mockito.mock;
+
+public class PoolWithMultiThreadedCacheTest extends AbstractServicePoolTestingHarness {
+    @Override
+    protected ServiceCachingPolicy getServiceCachingPolicy() {
+        // eviction delay is set to zero to invalidate an evicted instance immediately.
+        // this allows us to validate the call to ServiceFactory#destroy()
+        return ServiceCachingPolicyBuilder.getMultiThreadedClientPolicy();
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected ServiceFactory<Service> getServiceFactoryMock() {
+        // Multi threaded service cache requires the service factory to
+        // implement ThreadSafeServiceFactory (which extends ServiceFactory)
+        return (ServiceFactory<Service>) mock(MultiThreadedServiceFactory.class);
+    }
+}

--- a/core/src/test/java/com/bazaarvoice/ostrich/pool/PoolWithSingleThreadedCacheTest.java
+++ b/core/src/test/java/com/bazaarvoice/ostrich/pool/PoolWithSingleThreadedCacheTest.java
@@ -1,0 +1,99 @@
+package com.bazaarvoice.ostrich.pool;
+
+import com.bazaarvoice.ostrich.ServiceCallback;
+import com.bazaarvoice.ostrich.ServiceEndPoint;
+import com.bazaarvoice.ostrich.ServiceFactory;
+import com.bazaarvoice.ostrich.ServicePoolStatistics;
+import com.bazaarvoice.ostrich.exceptions.ServiceException;
+import org.junit.Test;
+import org.mockito.Matchers;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+public class PoolWithSingleThreadedCacheTest extends AbstractServicePoolTestingHarness {
+    @Override
+    protected ServiceCachingPolicy getServiceCachingPolicy() {
+        return new ServiceCachingPolicyBuilder().build();
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected ServiceFactory<AbstractServicePoolTestingHarness.Service> getServiceFactoryMock() {
+        return (ServiceFactory<Service>) mock(ServiceFactory.class);
+    }
+
+    @Test
+    public void testStatsNumIdleCachedInstancesIncrementsAfterExecute() {
+        // Make sure we only get FOO_ENDPOINT.
+        reset(_loadBalanceAlgorithm);
+        when(_loadBalanceAlgorithm.choose(Matchers.<Iterable<ServiceEndPoint>>any(), any(ServicePoolStatistics.class)))
+                .thenReturn(FOO_ENDPOINT);
+
+        final ServicePoolStatistics servicePoolStatistics = _pool.getServicePoolStatistics();
+
+        int numIdleDuringExecute = _pool.execute(NEVER_RETRY, new ServiceCallback<Service, Integer>() {
+            @Override
+            public Integer call(Service service)
+                    throws ServiceException {
+                return servicePoolStatistics.getNumIdleCachedInstances(FOO_ENDPOINT);
+            }
+        });
+
+        int numIdleAfterExecute = servicePoolStatistics.getNumIdleCachedInstances(FOO_ENDPOINT);
+
+        assertEquals(numIdleDuringExecute + 1, numIdleAfterExecute);
+    }
+
+    @Test
+    public void testStatsNumActiveInstancesDecrementsAfterExecute() {
+        // Make sure we only get FOO_ENDPOINT.
+        reset(_loadBalanceAlgorithm);
+        when(_loadBalanceAlgorithm.choose(Matchers.<Iterable<ServiceEndPoint>>any(), any(ServicePoolStatistics.class)))
+                .thenReturn(FOO_ENDPOINT);
+
+        final ServicePoolStatistics servicePoolStatistics = _pool.getServicePoolStatistics();
+
+        int numActiveDuringExecute = _pool.execute(NEVER_RETRY, new ServiceCallback<Service, Integer>() {
+            @Override
+            public Integer call(Service service)
+                    throws ServiceException {
+                return servicePoolStatistics.getNumActiveInstances(FOO_ENDPOINT);
+            }
+        });
+
+        int numActiveAfterExecute = servicePoolStatistics.getNumActiveInstances(FOO_ENDPOINT);
+
+        assertEquals(numActiveDuringExecute - 1, numActiveAfterExecute);
+    }
+
+    @SuppressWarnings ("unchecked")
+    @Test
+    public void testStatsNumIdleCachedInstancesDecrementsDuringExecute() {
+        // Make sure we only get FOO_ENDPOINT.
+        reset(_loadBalanceAlgorithm);
+        when(_loadBalanceAlgorithm.choose(Matchers.<Iterable<ServiceEndPoint>>any(), any(ServicePoolStatistics.class)))
+                .thenReturn(FOO_ENDPOINT);
+
+        // Prime the cache.
+        _pool.execute(NEVER_RETRY, mock(ServiceCallback.class));
+
+        final ServicePoolStatistics servicePoolStatistics = _pool.getServicePoolStatistics();
+
+        int numIdleInitially = servicePoolStatistics.getNumIdleCachedInstances(FOO_ENDPOINT);
+
+        int numIdleDuringExecute = _pool.execute(NEVER_RETRY, new ServiceCallback<Service, Integer>() {
+            @Override
+            public Integer call(Service service)
+                    throws ServiceException {
+                return servicePoolStatistics.getNumIdleCachedInstances(FOO_ENDPOINT);
+            }
+        });
+
+        assertEquals(numIdleInitially - 1, numIdleDuringExecute);
+    }
+
+}

--- a/core/src/test/java/com/bazaarvoice/ostrich/pool/ServiceCachingPolicyBuilderTest.java
+++ b/core/src/test/java/com/bazaarvoice/ostrich/pool/ServiceCachingPolicyBuilderTest.java
@@ -14,6 +14,20 @@ public class ServiceCachingPolicyBuilderTest {
 
         assertEquals(ServiceCachingPolicy.ExhaustionAction.GROW, builder.build().getCacheExhaustionAction());
     }
+
+    @Test
+    public void testUseMultiThreadedClientPolicy() {
+        ServiceCachingPolicy cachingPolicy = ServiceCachingPolicyBuilder.getMultiThreadedClientPolicy();
+
+        assertEquals(true, cachingPolicy.useMultiThreadedClientPolicy());
+    }
+
+    @Test
+    public void testDefaultMultiThreadedClientPolicy() {
+        ServiceCachingPolicyBuilder builder = new ServiceCachingPolicyBuilder();
+
+        assertEquals(false, builder.build().useMultiThreadedClientPolicy());
+    }
     
     @Test
     public void testMaxNumServiceInstancesSet() {
@@ -61,5 +75,29 @@ public class ServiceCachingPolicyBuilderTest {
     public void testInvalidMaxServiceInstanceIdleTime() {
         ServiceCachingPolicyBuilder builder = new ServiceCachingPolicyBuilder();
         builder.withMaxServiceInstanceIdleTime(0, TimeUnit.MILLISECONDS);
+    }
+
+    @Test (expected = UnsupportedOperationException.class)
+    public void testUseMultiThreadedClientPolicyWithMaxNumServiceInstancesPerEndPoint() {
+        ServiceCachingPolicy cachingPolicy = ServiceCachingPolicyBuilder.getMultiThreadedClientPolicy();
+        assertEquals(1, cachingPolicy.getMaxNumServiceInstancesPerEndPoint());
+    }
+
+    @Test (expected = UnsupportedOperationException.class)
+    public void testUseMultiThreadedClientPolicyWithMaxServiceInstanceIdleTime() {
+        ServiceCachingPolicy cachingPolicy = ServiceCachingPolicyBuilder.getMultiThreadedClientPolicy();
+        assertEquals(1, cachingPolicy.getMaxServiceInstanceIdleTime(TimeUnit.SECONDS));
+    }
+
+    @Test (expected = UnsupportedOperationException.class)
+    public void testUseMultiThreadedClientPolicyWithMaxNumServiceInstances() {
+        ServiceCachingPolicy cachingPolicy = ServiceCachingPolicyBuilder.getMultiThreadedClientPolicy();
+        assertEquals(1, cachingPolicy.getMaxNumServiceInstances());
+    }
+
+    @Test (expected = UnsupportedOperationException.class)
+    public void testUseMultiThreadedClientPolicyWithCacheExhaustionAction() {
+        ServiceCachingPolicy cachingPolicy = ServiceCachingPolicyBuilder.getMultiThreadedClientPolicy();
+        assertEquals(ServiceCachingPolicy.ExhaustionAction.GROW, cachingPolicy.getCacheExhaustionAction());
     }
 }

--- a/core/src/test/java/com/bazaarvoice/ostrich/pool/SingleThreadedClientServiceCacheTest.java
+++ b/core/src/test/java/com/bazaarvoice/ostrich/pool/SingleThreadedClientServiceCacheTest.java
@@ -41,13 +41,13 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class ServiceCacheTest {
+public class SingleThreadedClientServiceCacheTest {
     private static final ServiceEndPoint END_POINT = mock(ServiceEndPoint.class);
 
     private ServiceFactory<Service> _factory;
     private ServiceCachingPolicy _cachingPolicy;
     private MetricRegistry _registry = new MetricRegistry();
-    private List<ServiceCache<?>> _caches = Lists.newArrayList();
+    private List<SingleThreadedClientServiceCache<?>> _caches = Lists.newArrayList();
 
     @SuppressWarnings("unchecked")
     @Before
@@ -70,7 +70,7 @@ public class ServiceCacheTest {
 
     @After
     public void teardown() {
-        for (ServiceCache<?> cache : _caches) {
+        for (SingleThreadedClientServiceCache<?> cache : _caches) {
             cache.close();
         }
     }
@@ -125,7 +125,7 @@ public class ServiceCacheTest {
         NullPointerException exception = mock(NullPointerException.class);
         when(_factory.create(any(ServiceEndPoint.class))).thenThrow(exception);
 
-        ServiceCache<Service> cache = newCache();
+        SingleThreadedClientServiceCache<Service> cache = newCache();
         try {
             cache.checkOut(END_POINT);
             fail();
@@ -136,7 +136,7 @@ public class ServiceCacheTest {
 
     @Test
     public void testServiceInstanceIsReused() throws Exception {
-        ServiceCache<Service> cache = newCache();
+        SingleThreadedClientServiceCache<Service> cache = newCache();
         ServiceHandle<Service> handle = cache.checkOut(END_POINT);
         cache.checkIn(handle);
 
@@ -148,7 +148,7 @@ public class ServiceCacheTest {
         // Allow 2 instances per end point
         when(_cachingPolicy.getMaxNumServiceInstancesPerEndPoint()).thenReturn(2);
 
-        ServiceCache<Service> cache = newCache();
+        SingleThreadedClientServiceCache<Service> cache = newCache();
         ServiceHandle<Service> handle = cache.checkOut(END_POINT);
         assertNotSame(handle.getService(), cache.checkOut(END_POINT).getService());
     }
@@ -159,7 +159,7 @@ public class ServiceCacheTest {
         when(_factory.create(any(ServiceEndPoint.class))).thenReturn(service);
         when(_cachingPolicy.getMaxNumServiceInstancesPerEndPoint()).thenReturn(-1);
 
-        ServiceCache<Service> cache = newCache();
+        SingleThreadedClientServiceCache<Service> cache = newCache();
         ServiceHandle<Service> handle1 = cache.checkOut(END_POINT);
         ServiceHandle<Service> handle2 = cache.checkOut(END_POINT);
 
@@ -177,7 +177,7 @@ public class ServiceCacheTest {
         Service service = mock(Service.class);
         when(_factory.create(any(ServiceEndPoint.class))).thenReturn(service);
 
-        ServiceCache<Service> cache = newCache();
+        SingleThreadedClientServiceCache<Service> cache = newCache();
 
         ServiceEndPoint endPoint1 = mock(ServiceEndPoint.class);
         ServiceEndPoint endPoint2 = mock(ServiceEndPoint.class);
@@ -206,7 +206,7 @@ public class ServiceCacheTest {
         // Make the cache only hold one instance total.
         when(_cachingPolicy.getMaxNumServiceInstances()).thenReturn(1);
 
-        ServiceCache<Service> cache = newCache();
+        SingleThreadedClientServiceCache<Service> cache = newCache();
         ServiceHandle<Service> handle = cache.checkOut(END_POINT);
 
         cache.checkIn(handle);
@@ -218,7 +218,7 @@ public class ServiceCacheTest {
 
     @Test
     public void testEvictedEndPointDestroyedManualEviction() throws Exception {
-        ServiceCache<Service> cache = newCache();
+        SingleThreadedClientServiceCache<Service> cache = newCache();
         ServiceHandle<Service> handle = cache.checkOut(END_POINT);
         cache.checkIn(handle);
         cache.evict(END_POINT);
@@ -228,7 +228,7 @@ public class ServiceCacheTest {
 
     @Test
     public void testEvictedEndPointHasServiceInstancesRemovedFromCache() throws Exception {
-        ServiceCache<Service> cache = newCache();
+        SingleThreadedClientServiceCache<Service> cache = newCache();
 
         ServiceHandle<Service> handle = cache.checkOut(END_POINT);
         cache.checkIn(handle);
@@ -239,7 +239,7 @@ public class ServiceCacheTest {
 
     @Test
     public void testEvictedEndPointWhileServiceInstanceCheckedOut() throws Exception {
-        ServiceCache<Service> cache = newCache();
+        SingleThreadedClientServiceCache<Service> cache = newCache();
 
         ServiceHandle<Service> handle = cache.checkOut(END_POINT);
         cache.evict(END_POINT);
@@ -254,7 +254,7 @@ public class ServiceCacheTest {
         when(_factory.create(any(ServiceEndPoint.class))).thenReturn(service);
         when(_cachingPolicy.getMaxNumServiceInstancesPerEndPoint()).thenReturn(-1);
 
-        ServiceCache<Service> cache = newCache();
+        SingleThreadedClientServiceCache<Service> cache = newCache();
 
         ServiceHandle<Service> handle1 = cache.checkOut(END_POINT);
         ServiceHandle<Service> handle2 = cache.checkOut(END_POINT);
@@ -273,7 +273,7 @@ public class ServiceCacheTest {
         when(_factory.create(any(ServiceEndPoint.class))).thenReturn(service);
         when(_cachingPolicy.getMaxNumServiceInstancesPerEndPoint()).thenReturn(-1);
 
-        ServiceCache<Service> cache = newCache();
+        SingleThreadedClientServiceCache<Service> cache = newCache();
         ServiceHandle<Service> handle1 = cache.checkOut(END_POINT);
 
         cache.evict(END_POINT);
@@ -293,7 +293,7 @@ public class ServiceCacheTest {
         Service service = mock(Service.class);
         when(_factory.create(any(ServiceEndPoint.class))).thenReturn(service);
 
-        ServiceCache<Service> cache = newCache();
+        SingleThreadedClientServiceCache<Service> cache = newCache();
 
         ServiceHandle<Service> handle = cache.checkOut(END_POINT);
         cache.evict(END_POINT);
@@ -310,7 +310,7 @@ public class ServiceCacheTest {
         Service service = mock(Service.class);
         when(_factory.create(any(ServiceEndPoint.class))).thenReturn(service);
 
-        ServiceCache<Service> cache = newCache();
+        SingleThreadedClientServiceCache<Service> cache = newCache();
 
         ServiceEndPoint invalidEndPoint = mock(ServiceEndPoint.class);
         ServiceEndPoint validEndPoint = mock(ServiceEndPoint.class);
@@ -331,7 +331,7 @@ public class ServiceCacheTest {
     public void testFailCacheExhaustionAction() throws Exception {
         when(_cachingPolicy.getCacheExhaustionAction()).thenReturn(ServiceCachingPolicy.ExhaustionAction.FAIL);
 
-        ServiceCache<Service> cache = newCache();
+        SingleThreadedClientServiceCache<Service> cache = newCache();
         cache.checkOut(END_POINT);
         cache.checkOut(END_POINT);
     }
@@ -340,7 +340,7 @@ public class ServiceCacheTest {
     public void testGrowCacheExhaustionAction() throws Exception {
         when(_cachingPolicy.getCacheExhaustionAction()).thenReturn(ServiceCachingPolicy.ExhaustionAction.GROW);
 
-        ServiceCache<Service> cache = newCache();
+        SingleThreadedClientServiceCache<Service> cache = newCache();
         cache.checkOut(END_POINT);
         cache.checkOut(END_POINT);
     }
@@ -350,7 +350,7 @@ public class ServiceCacheTest {
         when(_cachingPolicy.getMaxNumServiceInstancesPerEndPoint()).thenReturn(1);
         when(_cachingPolicy.getCacheExhaustionAction()).thenReturn(ServiceCachingPolicy.ExhaustionAction.GROW);
 
-        ServiceCache<Service> cache = newCache();
+        SingleThreadedClientServiceCache<Service> cache = newCache();
 
         // Grow the cache a bunch, remembering each service that was created...
         Set<ServiceHandle<Service>> seenHandles = Sets.newHashSet();
@@ -380,7 +380,7 @@ public class ServiceCacheTest {
         when(_cachingPolicy.getMaxNumServiceInstancesPerEndPoint()).thenReturn(1);
         when(_cachingPolicy.getCacheExhaustionAction()).thenReturn(ServiceCachingPolicy.ExhaustionAction.WAIT);
 
-        final ServiceCache<Service> cache = newCache();
+        final SingleThreadedClientServiceCache<Service> cache = newCache();
         ServiceHandle<Service> handle = cache.checkOut(END_POINT);
 
         // Run a 2nd check out operation in a background thread.  It should block because there is only one service
@@ -434,40 +434,40 @@ public class ServiceCacheTest {
         newCache(executor);
         verify(executor).scheduleAtFixedRate(
                 any(Runnable.class),
-                eq(ServiceCache.EVICTION_DURATION_IN_SECONDS),
-                eq(ServiceCache.EVICTION_DURATION_IN_SECONDS),
+                eq(SingleThreadedClientServiceCache.EVICTION_DURATION_IN_SECONDS),
+                eq(SingleThreadedClientServiceCache.EVICTION_DURATION_IN_SECONDS),
                 eq(TimeUnit.SECONDS));
     }
 
     @Test(expected = NullPointerException.class)
     public void testNumIdleNullEndPoint() {
-        ServiceCache<Service> cache = newCache();
+        SingleThreadedClientServiceCache<Service> cache = newCache();
         cache.getNumIdleInstances(null);
     }
 
     @Test(expected = NullPointerException.class)
     public void testNumActiveNullEndPoint() {
-        ServiceCache<Service> cache = newCache();
+        SingleThreadedClientServiceCache<Service> cache = newCache();
         cache.getNumActiveInstances(null);
     }
 
     @Test
     public void testNumIdleStartsAtZero() {
-        ServiceCache<Service> cache = newCache();
+        SingleThreadedClientServiceCache<Service> cache = newCache();
 
         assertEquals(0, cache.getNumIdleInstances(END_POINT));
     }
 
     @Test
     public void testNumActiveStartsAtZero() {
-        ServiceCache<Service> cache = newCache();
+        SingleThreadedClientServiceCache<Service> cache = newCache();
 
         assertEquals(0, cache.getNumActiveInstances(END_POINT));
     }
 
     @Test
     public void testNumActiveUpdatedOnCheckOut() throws Exception {
-        ServiceCache<Service> cache = newCache();
+        SingleThreadedClientServiceCache<Service> cache = newCache();
         cache.checkOut(END_POINT);
 
         assertEquals(1, cache.getNumActiveInstances(END_POINT));
@@ -475,7 +475,7 @@ public class ServiceCacheTest {
 
     @Test
     public void testNumIdleUpdatedOnCheckIn() throws Exception {
-        ServiceCache<Service> cache = newCache();
+        SingleThreadedClientServiceCache<Service> cache = newCache();
         cache.checkIn(cache.checkOut(END_POINT));
 
         assertEquals(1, cache.getNumIdleInstances(END_POINT));
@@ -483,7 +483,7 @@ public class ServiceCacheTest {
 
     @Test
     public void testActiveServiceNotCountedIdle() throws Exception {
-        ServiceCache<Service> cache = newCache();
+        SingleThreadedClientServiceCache<Service> cache = newCache();
         cache.checkOut(END_POINT);
 
         assertEquals(0, cache.getNumIdleInstances(END_POINT));
@@ -491,7 +491,7 @@ public class ServiceCacheTest {
 
     @Test
     public void testIdleServiceNotCountedActive() throws Exception {
-        ServiceCache<Service> cache = newCache();
+        SingleThreadedClientServiceCache<Service> cache = newCache();
         cache.checkIn(cache.checkOut(END_POINT));
 
         assertEquals(0, cache.getNumActiveInstances(END_POINT));
@@ -502,7 +502,7 @@ public class ServiceCacheTest {
         when(_cachingPolicy.getMaxNumServiceInstancesPerEndPoint()).thenReturn(1);
         when(_cachingPolicy.getCacheExhaustionAction()).thenReturn(ServiceCachingPolicy.ExhaustionAction.GROW);
 
-        ServiceCache<Service> cache = newCache();
+        SingleThreadedClientServiceCache<Service> cache = newCache();
         cache.checkOut(END_POINT);
         cache.checkOut(END_POINT);
 
@@ -511,7 +511,7 @@ public class ServiceCacheTest {
 
     @Test
     public void testCloseDestroysCachedInstances() throws Exception {
-        ServiceCache<Service> cache = newCache();
+        SingleThreadedClientServiceCache<Service> cache = newCache();
         ServiceHandle<Service> handle = cache.checkOut(END_POINT);
         cache.checkIn(handle);
         cache.close();
@@ -519,7 +519,7 @@ public class ServiceCacheTest {
         verify(_factory).destroy(END_POINT, handle.getService());
     }
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings ({"unchecked", "rawtypes"})
     @Test
     public void testCloseCancelsEvictionFuture() {
         when(_cachingPolicy.getMaxServiceInstanceIdleTime(any(TimeUnit.class))).thenReturn(10L);
@@ -531,7 +531,7 @@ public class ServiceCacheTest {
                 anyLong(),
                 any(TimeUnit.class))).thenReturn(future);
 
-        ServiceCache<Service> cache = newCache(executor);
+        SingleThreadedClientServiceCache<Service> cache = newCache(executor);
         cache.close();
 
         verify(future).cancel(anyBoolean());
@@ -539,19 +539,19 @@ public class ServiceCacheTest {
 
     @Test
     public void testMultipleClose() {
-        ServiceCache<Service> cache = newCache();
+        SingleThreadedClientServiceCache<Service> cache = newCache();
         cache.close();
         cache.close();
     }
 
-    private ServiceCache<Service> newCache() {
-        ServiceCache<Service> cache = new ServiceCache<>(_cachingPolicy, _factory, _registry);
+    private SingleThreadedClientServiceCache<Service> newCache() {
+        SingleThreadedClientServiceCache<Service> cache = new SingleThreadedClientServiceCache<>(_cachingPolicy, _factory, _registry);
         _caches.add(cache);
         return cache;
     }
 
-    private ServiceCache<Service> newCache(ScheduledExecutorService executor) {
-        ServiceCache<Service> cache = new ServiceCache<>(_cachingPolicy, _factory, executor, _registry);
+    private SingleThreadedClientServiceCache<Service> newCache(ScheduledExecutorService executor) {
+        SingleThreadedClientServiceCache<Service> cache = new SingleThreadedClientServiceCache<>(_cachingPolicy, _factory, executor, _registry);
         _caches.add(cache);
         return cache;
     }

--- a/perf-test-suite/README.md
+++ b/perf-test-suite/README.md
@@ -70,12 +70,26 @@ After determining and setting those desired values the suite will run the desire
       -m,--max-instances <arg>    Max instances per end point in service cache,
                                   default is 10
 
+      -g,--singleton-mode         Run with singleton policy mode, default is
+                                  false
+
+      -n,--eviction-ttl <arg>     Eviction TTL for bad clients in singleton
+                                  policy mode, default is 5 second
+                                  crunch hash, default is 1024 X 5 (5kb)
+
 ### Overall load tweaking parameters
 
       -t,--thread-size <arg>      # of workers threads to run, default is 100
 
       -w,--work-size <arg>        length of the string to generate randomly and
                                   crunch hash, default is 5120 (5kb)
+
+### Chaos parameter to cause havoc on cache
+
+      -c,--chaos-count <arg>      Number of chaos workers to use, default is 2
+
+      -l,--chaos-interval <arg>   time (in seconds) to wait between chaos,
+                                   default is 15
 
 ### I/O and runtime parameters
 
@@ -155,27 +169,37 @@ A CSV style output provides a number of metrics, it can either be STDOUT or if p
  
 Example:
 
-    counter,cr-totl,cr-mnrt,cr-1mrt,cr-5mrt,cr-15rt,dt-totl,dt-mnrt,dt-1mrt,dt-5mrt,dt-15rt,sc-totl,sc-mnrt,sc-1mrt,sc-5mrt,sc-15rt,co-totl,co-min,co-max,co-mean,co-1mrt,co-5mrt,co-15rt,ci-totl,ci-min,ci-max,ci-mean,ci-1mrt,ci-5mrt,ci-15rt,st-totl,st-min,st-max,st-mean,st-1mrt,st-5mrt,st-15rt,tt-totl,tt-min,tt-max,tt-mean,tt-1mrt,tt-5mrt,tt-15rt,
-    0,100,599.86,0.00,0.00,0.00,0,0.00,0.00,0.00,0.00,0,0.00,0.00,0.00,0.00,100,0.10,33.07,11.70,0.00,0.00,0.00,0,0.00,0.00,0.00,0.00,0.00,0.00,0,0.00,0.00,0.00,0.00,0.00,0.00,0,0.00,0.00,0.00,0.00,0.00,0.00,
-    1,1516,1286.03,0.00,0.00,0.00,0,0.00,0.00,0.00,0.00,1495,1346.02,0.00,0.00,0.00,1513,0.07,234.06,19.36,0.00,0.00,0.00,1497,0.02,232.63,8.97,0.00,0.00,0.00,1513,0.15,443.13,29.43,0.00,0.00,0.00,1500,0.36,538.90,58.12,0.00,0.00,0.00,
+    counter,cr-totl,cr-mnrt,cr-1mrt,cr-5mrt,cr-15rt,dt-totl,dt-mnrt,dt-1mrt,dt-5mrt,dt-15rt,\
+        sc-totl,sc-mnrt,sc-1mrt,sc-5mrt,sc-15rt,co-totl,co-min,co-max,co-mean,co-1mrt,co-5mrt,co-15rt,\
+        ci-totl,ci-min,ci-max,ci-mean,ci-1mrt,ci-5mrt,ci-15rt,st-totl,st-min,st-max,st-mean,st-1mrt,st-5mrt,st-15rt,\
+        tt-totl,tt-min,tt-max,tt-mean,tt-1mrt,tt-5mrt,tt-15rt,
+    0,100,599.86,0.00,0.00,0.00,0,0.00,0.00,0.00,0.00,0,0.00,0.00,0.00,0.00,100,0.10,33.07,11.70,0.00,0.00,0.00,0,\
+        0.00,0.00,0.00,0.00,0.00,0.00,0,0.00,0.00,0.00,0.00,0.00,0.00,0,0.00,0.00,0.00,0.00,0.00,0.00,
+    1,1516,1286.03,0.00,0.00,0.00,0,0.00,0.00,0.00,0.00,1495,1346.02,0.00,0.00,0.00,1513,0.07,\234.06,19.36,0.00,0.00,\
+        0.00,1497,0.02,232.63,8.97,0.00,0.00,0.00,1513,0.15,443.13,29.43,0.00,0.00,0.00,1500,0.36,538.90,58.12,0.00,0.00,0.00,
 
 
 #### Rolling statistics
 
 If requested (via --statistics / -s) a rolling statistics output on STDOUT provides the following metrics:
- 
-    service created & destroyed, with total count and 1 minute, 5 minute, 15 minute and mean rates
- 
-    service times (just the hash) & total time (service plus ostrich overhead) with total number of execution and 1 minute, 5 minute, 15 minute and mean rates of each execution
- 
-    checkin & checkout times with total number of check in and check outs, and 1 minute, 5 minute, 15 minute and mean rates of each check in and check out
 
-#### Example:
+    <Current date-time>
+    Running ## seconds of <total-runtime> with threads: ##, work size: ##, idle time: ##, max instance: ##, \
+            exhaust action: <>, singleton-mode: <>, eviction-ttl: ##, chaos-worker: ##, chaos-interval: ##
+    Called count: ####    Cache Miss: ####    Failed Count: ####    Service Created: ####    Service Destroyed: #### \
+            Chaos: ####    Stable: ####    Register: ####    Evict: ####    Load: ####
 
-    Running 5 seconds of 30 with threads: 25, work size: 12000, idle time: 10, max instance: 10, exhaust action: GROW
-        created / destroyed    -- total:     3651 /        0  1-min: 708.20/s / 0.00/s      5-min: 708.20/s / 0.00/s      15-min: 708.20/s / 0.00/s      mean: 706.61/s / 0.00/s
-        service / total        -- total:     3648 /     3648  1-min: 708.60/s / 719.60/s    5-min: 708.60/s / 719.60/s    15-min: 708.60/s / 719.60/s    mean: 5.24ms / 7.84ms
-        checkout / checkin     -- total:     3652 /     3649  1-min: 720.00/s / 719.60/s    5-min: 720.00/s / 719.60/s    15-min: 720.00/s / 719.60/s    mean: 1.73ms / 0.70ms
+    created / destroyed   -- 1-min: #.##/s / #.##/s    5-min: #.##/s / #.##/s      15-min: #.##/s / #.##/s    mean: #.##/s / #.##/s
+    chaos / stable        -- 1-min: #.##/s / #.##/s    5-min: #.##/s / #.##/s      15-min: #.##/s / #.##/s    mean: #.##/s / #.##/s
+    executed / failure    -- 1-min: #.##/s / #.##/s    5-min: #.##/s / #.##/s      15-min: #.##/s / #.##/s    mean: #.##/s / #.##/s
+    service / total       -- 1-min: #.##/s / #.##/s    5-min: #.##/s / #.##/s      15-min: #.##/s / #.##/s    mean: #.##/s / #.##/s
+    checkout / checkin    -- 1-min: #.##/s / #.##/s    5-min: #.##/s / #.##/s      15-min: #.##/s / #.##/s    mean: #.##/s / #.##/s
+
+    Service     -- mean: #.##ms    min: #.##ms    max: #.##ms    75th: #.##ms    95th: #.##ms    98th: #.##ms    99th: #.##ms    999th: #.##ms
+    Checkout    -- mean: #.##ms    min: #.##ms    max: #.##ms    75th: #.##ms    95th: #.##ms    98th: #.##ms    99th: #.##ms    999th: #.##ms
+    Checkin     -- mean: #.##ms    min: #.##ms    max: #.##ms    75th: #.##ms    95th: #.##ms    98th: #.##ms    99th: #.##ms    999th: #.##ms
+    Total       -- mean: #.##ms    min: #.##ms    max: #.##ms    75th: #.##ms    95th: #.##ms    98th: #.##ms    99th: #.##ms    999th: #.##ms
+
 
 ## Running Example
 

--- a/perf-test-suite/pom.xml
+++ b/perf-test-suite/pom.xml
@@ -16,7 +16,7 @@
     <version>0.1</version>
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
-        <ostrich.core.version>${parent.version}</ostrich.core.version>
+        <ostrich.core.version>${project.parent.version}</ostrich.core.version>
     </properties>
 
     <dependencies>

--- a/perf-test-suite/src/main/java/com/bazaarvoice/ostrich/perftest/core/SimpleServiceFactory.java
+++ b/perf-test-suite/src/main/java/com/bazaarvoice/ostrich/perftest/core/SimpleServiceFactory.java
@@ -1,7 +1,7 @@
 package com.bazaarvoice.ostrich.perftest.core;
 
 import com.bazaarvoice.ostrich.ServiceEndPoint;
-import com.bazaarvoice.ostrich.ServiceFactory;
+import com.bazaarvoice.ostrich.MultiThreadedServiceFactory;
 import com.bazaarvoice.ostrich.metrics.Metrics;
 import com.bazaarvoice.ostrich.perftest.utils.HashFunction;
 import com.bazaarvoice.ostrich.pool.ServicePoolBuilder;
@@ -12,12 +12,11 @@ import com.codahale.metrics.Timer;
 /**
  * A service factory, as needed in the ServiceCache
  */
-public class SimpleServiceFactory implements ServiceFactory<Service<String, String>> {
+public class SimpleServiceFactory implements MultiThreadedServiceFactory<Service<String, String>> {
 
     private final Meter _serviceCreated;
     private final Meter _serviceDestroyed;
     private final Timer _serviceTimer;
-
 
     /**
      * private constructor
@@ -74,33 +73,6 @@ public class SimpleServiceFactory implements ServiceFactory<Service<String, Stri
     @Override
     public boolean isRetriableException(Exception exception) {
         throw new RuntimeException("isRetriableException() should not get executed as part the performance test suite");
-    }
-
-    /**
-     * exposes the service created meter
-     *
-     * @return service created meter
-     */
-    public Meter getServiceCreated() {
-        return _serviceCreated;
-    }
-
-    /**
-     * exposes the service destroyed meter
-     *
-     * @return service destroyed meter
-     */
-    public Meter getServiceDestroyed() {
-        return _serviceDestroyed;
-    }
-
-    /**
-     * exposes the service timer meter
-     *
-     * @return service timer meter
-     */
-    public Timer getServiceTimer() {
-        return _serviceTimer;
     }
 
     /**

--- a/perf-test-suite/src/main/java/com/bazaarvoice/ostrich/perftest/utils/Arguments.java
+++ b/perf-test-suite/src/main/java/com/bazaarvoice/ostrich/perftest/utils/Arguments.java
@@ -25,10 +25,13 @@ public class Arguments {
     private long _runTimeSecond = Long.MAX_VALUE;
     private int _maxInstance = 10;
     private int _idleTimeSecond = 10;
+    private boolean _runSingletonMode = false;
     private ExhaustionAction _exhaustionAction = ExhaustionAction.WAIT;
     private int _reportingIntervalSeconds = 1;
     private PrintStream _output = System.out;
     private boolean _printStats = false;
+    private int _chaosWorkers = 2;
+    private int _chaosInterval = 15;
 
 
     public Arguments(String[] args) {
@@ -71,6 +74,18 @@ public class Arguments {
         return _reportingIntervalSeconds;
     }
 
+    public boolean isRunSingletonMode() {
+        return _runSingletonMode;
+    }
+
+    public int getChaosWorkers() {
+        return _chaosWorkers;
+    }
+
+    public int getChaosInterval() {
+        return _chaosInterval;
+    }
+
     private void parseArgs(String[] args) {
 
         Options options = new Options();
@@ -84,6 +99,11 @@ public class Arguments {
         options.addOption("m", "max-instances", true, "Max instances per end point in service cache, default is 10");
         options.addOption("i", "idle-time", true, "Idle time before service cache should take evict action, default is 10");
         options.addOption("e", "exhaust-action", true, "Exhaust action when cache is exhausted, acceptable values are WAIT|FAIL|GROW, default is WAIT");
+
+        options.addOption("g", "singleton-mode", false, "Run with singleton policy mode, default is false");
+
+        options.addOption("c", "chaos-count", true, "Number of chaos workers to use, default is 2");
+        options.addOption("l", "chaos-interval", true, "time (in seconds) to wait between chaos, default is 15");
 
         options.addOption("o", "output-file", true, "Output file to use instead of STDOUT");
         options.addOption("v", "report-every", true, "Reports the running statistics every # seconds");
@@ -129,16 +149,24 @@ public class Arguments {
                     case "o":
                         _output = createPrintStream(value);
                         break;
+                    case "g":
+                        _runSingletonMode = true;
+                        break;
                     case "s":
                         _printStats = true;
                         break;
                     case "v":
                         _reportingIntervalSeconds = Integer.parseInt(value);
                         break;
+                    case "c":
+                        _chaosWorkers = Integer.parseInt(value);
+                        break;
+                    case "l":
+                        _chaosInterval = Integer.parseInt(value);
+                        break;
                 }
             }
             if (_output == System.out && _printStats) {
-
                 throw new Exception("Cannot print both report log and statistics to STDOUT at the same time");
             }
         } catch (IllegalArgumentException ex) {

--- a/perf-test-suite/src/main/java/com/bazaarvoice/ostrich/perftest/utils/ChaosRunner.java
+++ b/perf-test-suite/src/main/java/com/bazaarvoice/ostrich/perftest/utils/ChaosRunner.java
@@ -1,0 +1,59 @@
+package com.bazaarvoice.ostrich.perftest.utils;
+
+import com.bazaarvoice.ostrich.ServiceEndPoint;
+import com.bazaarvoice.ostrich.metrics.Metrics;
+import com.bazaarvoice.ostrich.perftest.core.Service;
+import com.bazaarvoice.ostrich.pool.ServiceCache;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+public class ChaosRunner {
+
+    private final ServiceCache<Service<String, String>> _serviceCache;
+    private final int _chaosWorkers;
+    private final Meter _chaosMeter, _stableMeter;
+    private final int _chaosInterval;
+
+    public ChaosRunner(ServiceCache<Service<String, String>> serviceCache, Arguments arguments, MetricRegistry metricRegistry) {
+        _serviceCache = serviceCache;
+        _chaosWorkers = arguments.getChaosWorkers();
+        Metrics.InstanceMetrics _metrics = Metrics.forInstance(metricRegistry, this, "ChaosRunner");
+        _chaosMeter = _metrics.meter("Chaos");
+        _stableMeter = _metrics.meter("Stable");
+        _chaosInterval = arguments.getChaosInterval();
+    }
+
+    public List<Thread> generateChaosWorkers() {
+        ImmutableList.Builder<Thread> chaosWorkersBuilder = ImmutableList.builder();
+        for(int i=0; i<_chaosWorkers; i++) {
+            Runnable runnable = new Runnable() {
+                @Override
+                public void run() {
+                    while(!Thread.interrupted()) {
+                        try {
+                            int sleepTime = Utilities.getRandomInt(_chaosInterval);
+                            Utilities.sleepForSeconds(sleepTime);
+                            String hashName = HashFunction.getRandomHashName();
+                            ServiceEndPoint endPoint = Utilities.buildServiceEndPoint(hashName);
+                            _serviceCache.evict(endPoint);
+                            _chaosMeter.mark();
+                            Utilities.sleepForSeconds(_chaosInterval - sleepTime);
+                            _serviceCache.register(endPoint);
+                            _stableMeter.mark();
+                        }
+                        catch(Exception ignored) {
+                            ignored.printStackTrace();
+                        }
+                    }
+                }
+            };
+            chaosWorkersBuilder.add(new Thread(runnable));
+        }
+        return chaosWorkersBuilder.build();
+    }
+
+
+}

--- a/perf-test-suite/src/main/java/com/bazaarvoice/ostrich/perftest/utils/HashFunction.java
+++ b/perf-test-suite/src/main/java/com/bazaarvoice/ostrich/perftest/utils/HashFunction.java
@@ -2,7 +2,8 @@ package com.bazaarvoice.ostrich.perftest.utils;
 
 import org.apache.commons.codec.digest.DigestUtils;
 
-import java.util.Random;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * Various singleton hash function to mimic workload
@@ -44,12 +45,12 @@ public enum HashFunction {
             return DigestUtils.md5Hex(work);
         }
     };
-    private static final int RANDOM_HASH_FUNCTION_LIMIT = HashFunction.values().length;
-    private static final Random RANDOM = new Random();
-
-    public static HashFunction getRandomHashFunction() {
-        return HashFunction.values()[RANDOM.nextInt(RANDOM_HASH_FUNCTION_LIMIT)];
-    }
 
     public abstract String process(String work);
+
+    private static final List<HashFunction> HASH_FUNCTION_LIST = Arrays.asList(HashFunction.values());
+
+    public static String getRandomHashName() {
+        return HASH_FUNCTION_LIST.get(Utilities.getRandomInt(HASH_FUNCTION_LIST.size())).name();
+    }
 }

--- a/perf-test-suite/src/main/java/com/bazaarvoice/ostrich/perftest/utils/Utilities.java
+++ b/perf-test-suite/src/main/java/com/bazaarvoice/ostrich/perftest/utils/Utilities.java
@@ -1,0 +1,38 @@
+package com.bazaarvoice.ostrich.perftest.utils;
+
+import com.bazaarvoice.ostrich.ServiceEndPoint;
+import com.bazaarvoice.ostrich.ServiceEndPointBuilder;
+
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+public class Utilities {
+
+    private static final ThreadLocalRandom RANDOM = ThreadLocalRandom.current();
+    private Utilities() {
+    }
+
+    /**
+     * Creates a serviceEndPoint to hash a string with a given hash function
+     *
+     * @param hashFunctionName to delegate the work
+     * @return an appropriate serviceEndPoint for the job
+     */
+    public static ServiceEndPoint buildServiceEndPoint(String hashFunctionName) {
+        return new ServiceEndPointBuilder()
+                .withServiceName(hashFunctionName)
+                .withId(hashFunctionName)
+                .build();
+    }
+
+    public static void sleepForSeconds(int seconds) {
+        try {
+            Thread.sleep(TimeUnit.SECONDS.toMillis(seconds));
+        } catch (InterruptedException ignored) {
+        }
+    }
+
+    public static int getRandomInt(int limit) {
+        return RANDOM.nextInt(limit);
+    }
+}


### PR DESCRIPTION
	  Created SingleThreaded and MultiThreaded service cache
	  Simplified, we just have a copy-on-write map and a single cleanup thread now
	  Added marker interface to force a specific type of service factory in multi thread cache
	  Updated perf-test-suite to use new multi threaded cache
	  Updated test suite with more metrics, added chaos worked to create chaos while test run
	  Updatd service pool test to test both cache
	  Fix all the docs