### PR TITLE
POLLOI-1826 guava upgrade for ES 2.1.

### DIFF
--- a/core/src/main/java/com/bazaarvoice/ostrich/pool/ServicePoolProxies.java
+++ b/core/src/main/java/com/bazaarvoice/ostrich/pool/ServicePoolProxies.java
@@ -3,6 +3,7 @@ package com.bazaarvoice.ostrich.pool;
 import com.bazaarvoice.ostrich.HealthCheckResults;
 import com.google.common.io.Closeables;
 
+import java.io.IOException;
 import java.lang.reflect.Proxy;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -31,7 +32,11 @@ public abstract class ServicePoolProxies {
      */
     public static <S> void close(S dynamicProxy) {
         // Use closeQuietly since ServicePool.close() doesn't throw IOException.
-        Closeables.closeQuietly(getPool(dynamicProxy));
+        try {
+            Closeables.close(getPool(dynamicProxy), true);
+        } catch (IOException e) {
+            throw new AssertionError();  // close swallows IOExceptions
+        }
     }
 
     /**

--- a/core/src/test/java/com/bazaarvoice/ostrich/discovery/FixedHostDiscoveryTest.java
+++ b/core/src/test/java/com/bazaarvoice/ostrich/discovery/FixedHostDiscoveryTest.java
@@ -35,7 +35,7 @@ public class FixedHostDiscoveryTest {
 
     @After
     public void teardown() throws Exception {
-        Closeables.closeQuietly(_discovery);
+        Closeables.close(_discovery, true);
     }
 
     @Test(expected = NullPointerException.class)

--- a/core/src/test/java/com/bazaarvoice/ostrich/pool/AsyncServicePoolTest.java
+++ b/core/src/test/java/com/bazaarvoice/ostrich/pool/AsyncServicePoolTest.java
@@ -56,9 +56,9 @@ public class AsyncServicePoolTest {
     }
 
     @After
-    public void teardown() {
+    public void teardown() throws IOException {
         for (AsyncServicePool<Service> pool : _asyncServicePools) {
-            Closeables.closeQuietly(pool);
+            Closeables.close(pool, true);
         }
     }
 

--- a/examples/calculator/user/src/main/java/com/bazaarvoice/ostrich/examples/calculator/user/CalculatorProxyUser.java
+++ b/examples/calculator/user/src/main/java/com/bazaarvoice/ostrich/examples/calculator/user/CalculatorProxyUser.java
@@ -10,7 +10,6 @@ import com.bazaarvoice.ostrich.pool.ServicePoolBuilder;
 import com.bazaarvoice.ostrich.pool.ServicePoolProxies;
 import com.bazaarvoice.ostrich.retry.ExponentialBackoffRetry;
 import com.google.common.io.Closeables;
-import org.apache.curator.framework.CuratorFramework;
 import com.yammer.dropwizard.config.ConfigurationException;
 import com.yammer.dropwizard.config.ConfigurationFactory;
 import com.yammer.dropwizard.util.JarLocation;
@@ -20,6 +19,7 @@ import net.sourceforge.argparse4j.ArgumentParsers;
 import net.sourceforge.argparse4j.inf.ArgumentParser;
 import net.sourceforge.argparse4j.inf.ArgumentParserException;
 import net.sourceforge.argparse4j.inf.Namespace;
+import org.apache.curator.framework.CuratorFramework;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -101,7 +101,7 @@ public class CalculatorProxyUser {
         user.use();
 
         ServicePoolProxies.close(service);
-        Closeables.closeQuietly(curator);
+        Closeables.close(curator, true);
     }
 
     private static Namespace parseCommandLine(String[] args) throws ArgumentParserException {

--- a/examples/calculator/user/src/main/java/com/bazaarvoice/ostrich/examples/calculator/user/CalculatorUser.java
+++ b/examples/calculator/user/src/main/java/com/bazaarvoice/ostrich/examples/calculator/user/CalculatorUser.java
@@ -12,7 +12,6 @@ import com.bazaarvoice.ostrich.pool.ServiceCachingPolicyBuilder;
 import com.bazaarvoice.ostrich.pool.ServicePoolBuilder;
 import com.bazaarvoice.ostrich.retry.ExponentialBackoffRetry;
 import com.google.common.io.Closeables;
-import org.apache.curator.framework.CuratorFramework;
 import com.yammer.dropwizard.config.ConfigurationException;
 import com.yammer.dropwizard.config.ConfigurationFactory;
 import com.yammer.dropwizard.util.JarLocation;
@@ -22,6 +21,7 @@ import net.sourceforge.argparse4j.ArgumentParsers;
 import net.sourceforge.argparse4j.inf.ArgumentParser;
 import net.sourceforge.argparse4j.inf.ArgumentParserException;
 import net.sourceforge.argparse4j.inf.Namespace;
+import org.apache.curator.framework.CuratorFramework;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -104,8 +104,8 @@ public class CalculatorUser {
         CalculatorUser user = new CalculatorUser(pool);
         user.use();
 
-        Closeables.closeQuietly(pool);
-        Closeables.closeQuietly(curator);
+        Closeables.close(pool, true);
+        Closeables.close(curator, true);
     }
 
     private static Namespace parseCommandLine(String[] args) throws ArgumentParserException {

--- a/examples/dictionary/user/src/main/java/com/bazaarvoice/ostrich/examples/dictionary/user/DictionaryUser.java
+++ b/examples/dictionary/user/src/main/java/com/bazaarvoice/ostrich/examples/dictionary/user/DictionaryUser.java
@@ -15,7 +15,6 @@ import com.google.common.base.Splitter;
 import com.google.common.io.Closeables;
 import com.google.common.io.Files;
 import com.google.common.io.LineProcessor;
-import org.apache.curator.framework.CuratorFramework;
 import com.yammer.dropwizard.config.ConfigurationException;
 import com.yammer.dropwizard.config.ConfigurationFactory;
 import com.yammer.dropwizard.util.JarLocation;
@@ -25,6 +24,7 @@ import net.sourceforge.argparse4j.ArgumentParsers;
 import net.sourceforge.argparse4j.inf.ArgumentParser;
 import net.sourceforge.argparse4j.inf.ArgumentParserException;
 import net.sourceforge.argparse4j.inf.Namespace;
+import org.apache.curator.framework.CuratorFramework;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -119,7 +119,7 @@ public class DictionaryUser {
         }
 
         ServicePoolProxies.close(service);
-        Closeables.closeQuietly(curator);
+        Closeables.close(curator, true);
     }
 
     private static Namespace parseCommandLine(String[] args) throws ArgumentParserException {

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>14.0.1</version>
+                <version>15.0</version>
             </dependency>
 
             <dependency>

--- a/zookeeper/discovery/src/test/java/com/bazaarvoice/ostrich/discovery/zookeeper/ZooKeeperHostDiscoveryTest.java
+++ b/zookeeper/discovery/src/test/java/com/bazaarvoice/ostrich/discovery/zookeeper/ZooKeeperHostDiscoveryTest.java
@@ -65,7 +65,7 @@ public class ZooKeeperHostDiscoveryTest {
 
     @After
     public void teardown() throws Exception {
-        Closeables.closeQuietly(_discovery);
+        Closeables.close(_discovery, true);
     }
 
     @Test (expected = NullPointerException.class)

--- a/zookeeper/discovery/src/test/java/com/bazaarvoice/ostrich/discovery/zookeeper/ZooKeeperServiceDiscoveryTest.java
+++ b/zookeeper/discovery/src/test/java/com/bazaarvoice/ostrich/discovery/zookeeper/ZooKeeperServiceDiscoveryTest.java
@@ -32,7 +32,7 @@ public class ZooKeeperServiceDiscoveryTest {
 
     @After
     public void teardown() throws Exception {
-        Closeables.closeQuietly(_discovery);
+        Closeables.close(_discovery, true);
     }
 
     @Test(expected = NullPointerException.class)


### PR DESCRIPTION
This makes ostrich 1.7.X compatible with Guvava 15 to Guava 18. I need this because ES 2.1.0 uses Guava 18. Note that I cannot upgrade polloi to latest version of ostrich - reason is that it comes with DW 7 which will force all polloi clients to switch to DW 7. 