### PR TITLE
Fix valid characters to be able to use URL as endpoint names

### DIFF
--- a/core/src/main/java/com/bazaarvoice/ostrich/ServiceEndPointBuilder.java
+++ b/core/src/main/java/com/bazaarvoice/ostrich/ServiceEndPointBuilder.java
@@ -15,7 +15,7 @@ public class ServiceEndPointBuilder {
             .or(CharMatcher.inRange('a', 'z'))
             .or(CharMatcher.inRange('A', 'Z'))
             .or(CharMatcher.inRange('0', '9'))
-            .or(CharMatcher.anyOf("._-:"))
+            .or(CharMatcher.anyOf("._-:/"))
             .precomputed();
 
     private Optional<String> _serviceName = Optional.absent();

--- a/core/src/test/java/com/bazaarvoice/ostrich/ServiceEndPointBuilderTest.java
+++ b/core/src/test/java/com/bazaarvoice/ostrich/ServiceEndPointBuilderTest.java
@@ -22,6 +22,16 @@ public class ServiceEndPointBuilderTest {
     }
 
     @Test
+    public void testUrlLikeId() {
+        // Allow characters that can appear in a URL without needing escaping (e.g. prod://services/profile-v1)
+        new ServiceEndPointBuilder()
+                // example taken directly from the comments in ServiceEndPointBuilder.VALID_CHARACTERS
+                .withId("prod://services/profile-v1")
+                .withServiceName("service")
+                .build();
+    }
+
+    @Test
     public void testServiceName() {
         ServiceEndPoint endPoint = new ServiceEndPointBuilder()
                 .withServiceName("service")


### PR DESCRIPTION
Although the inline comments claim to allow referring services with a URL, it doesn't work as '/' is not considered a valid character.