### PR TITLE
Add "shaded-guava" classifier to ostrich-core

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -53,4 +53,38 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.1.1</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <relocations>
+                                <relocation>
+                                    <pattern>com.google</pattern>
+                                    <shadedPattern>com.bazaarvoice.ostrich.internal.shaded.com.google</shadedPattern>
+                                </relocation>
+                            </relocations>
+                            <minimizeJar>true</minimizeJar>
+                            <artifactSet>
+                                <includes>
+                                    <include>com.google.guava:guava</include>
+                                </includes>
+                            </artifactSet>
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <shadedClassifierName>shaded-guava</shadedClassifierName>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <dropwizard.version>0.7.1</dropwizard.version>
         <slf4j.version>1.7.21</slf4j.version>
         <logback.version>1.2.3</logback.version>
-        <jackson.version>2.9.4</jackson.version>
+        <jackson.version>2.9.6</jackson.version>
     </properties>
 
     <build>


### PR DESCRIPTION
The EmoDB team is working to remove as many dependencies from our client libraries as possible in order to make the client easier to use. One of the dependencies we are trying to remove is guava. Ostrich-core currently directly depends on guava, and it is therefore a transitive dependency in Emo's client libraries. 

This PR adds a "shaded-guava" classifier to ostrich-core that shades in guava, which allows us to continue using ostrich.

Additionally, I upgraded jackson due to a reported security vulnerability that was causing the build to fail.