### PR TITLE
Update dependencies

### DIFF
--- a/core/src/main/java/com/bazaarvoice/ostrich/pool/AnnotationPartitionContextSupplier.java
+++ b/core/src/main/java/com/bazaarvoice/ostrich/pool/AnnotationPartitionContextSupplier.java
@@ -9,6 +9,7 @@ import com.google.common.collect.Maps;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -37,6 +38,9 @@ class AnnotationPartitionContextSupplier implements PartitionContextSupplier {
 
         ImmutableMap.Builder<Method, String[]> builder = ImmutableMap.builder();
         for (Method ifcMethod : ifc.getMethods()) {
+            if (Modifier.isStatic(ifcMethod.getModifiers())) {
+                continue; // Static methods of ifc aren't members of impl.
+            }
             Method implMethod;
             try {
                 implMethod = impl.getMethod(ifcMethod.getName(), ifcMethod.getParameterTypes());

--- a/core/src/test/java/com/bazaarvoice/ostrich/pool/AnnotationPartitionContextSupplierTest.java
+++ b/core/src/test/java/com/bazaarvoice/ostrich/pool/AnnotationPartitionContextSupplierTest.java
@@ -138,6 +138,13 @@ public class AnnotationPartitionContextSupplierTest {
         assertEquals(ImmutableMap.<String, Object>of("", "value"), partitionContext.asMap());
     }
 
+    @Test
+    public void testStaticMethod() throws Exception {
+        PartitionContextSupplier contextSupplier =
+                new AnnotationPartitionContextSupplier(MyServiceImpl.class, MyExtendedServiceImpl.class);
+        assertTrue(contextSupplier.forCall(MyServiceImpl.class.getMethod("staticMethod")).asMap().isEmpty());
+    }
+
     private static interface MyService {
         void noArgs();
         void unnamed(String string);
@@ -155,6 +162,8 @@ public class AnnotationPartitionContextSupplierTest {
     }
 
     private static class MyServiceImpl implements MyService {
+        // Java 8+ interfaces support static methods, but test on a class for Java 7 compatibility.
+        public static void staticMethod() {}
         @Override
         public void noArgs() {}
         @Override

--- a/dropwizard/pom.xml
+++ b/dropwizard/pom.xml
@@ -25,7 +25,6 @@
         <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-core</artifactId>
-            <version>${dropwizard.version}</version>
         </dependency>
 
         <dependency>

--- a/examples/calculator/client/src/main/java/com/bazaarvoice/ostrich/examples/calculator/client/CalculatorClient.java
+++ b/examples/calculator/client/src/main/java/com/bazaarvoice/ostrich/examples/calculator/client/CalculatorClient.java
@@ -1,8 +1,8 @@
 package com.bazaarvoice.ostrich.examples.calculator.client;
 
 import com.bazaarvoice.ostrich.ServiceEndPoint;
-import com.sun.jersey.api.client.Client;
 
+import javax.ws.rs.client.Client;
 import javax.ws.rs.core.UriBuilder;
 import java.net.URI;
 
@@ -42,7 +42,12 @@ public class CalculatorClient implements CalculatorService {
     }
 
     private int call(String op, int a, int b) {
-        URI uri = _service.clone().segment(op, Integer.toString(a), Integer.toString(b)).build();
-        return _client.resource(uri).get(Integer.class);
+        return _client
+                .target(_service)
+                .path(op)
+                .path(Integer.toString(a))
+                .path(Integer.toString(b))
+                .request()
+                .get(Integer.class);
     }
 }

--- a/examples/calculator/client/src/main/java/com/bazaarvoice/ostrich/examples/calculator/client/CalculatorServiceFactory.java
+++ b/examples/calculator/client/src/main/java/com/bazaarvoice/ostrich/examples/calculator/client/CalculatorServiceFactory.java
@@ -69,6 +69,6 @@ public class CalculatorServiceFactory implements ServiceFactory<CalculatorServic
         Response response = _client.target(adminUrl).path("/healthcheck").request().method("HEAD");
         int status = response.getStatus();
         response.close();
-        return status == 200;
+        return status == Response.Status.OK.getStatusCode();
     }
 }

--- a/examples/calculator/client/src/main/java/com/bazaarvoice/ostrich/examples/calculator/client/CalculatorServiceFactory.java
+++ b/examples/calculator/client/src/main/java/com/bazaarvoice/ostrich/examples/calculator/client/CalculatorServiceFactory.java
@@ -4,21 +4,13 @@ import com.bazaarvoice.ostrich.ServiceEndPoint;
 import com.bazaarvoice.ostrich.ServiceFactory;
 import com.bazaarvoice.ostrich.pool.ServicePoolBuilder;
 import com.codahale.metrics.MetricRegistry;
-import com.sun.jersey.api.client.Client;
-import com.sun.jersey.api.client.ClientHandlerException;
-import com.sun.jersey.api.client.UniformInterfaceException;
-import com.sun.jersey.client.apache4.ApacheHttpClient4;
-import com.sun.jersey.client.apache4.ApacheHttpClient4Handler;
-import com.sun.jersey.client.apache4.config.ApacheHttpClient4Config;
-import com.sun.jersey.client.apache4.config.DefaultApacheHttpClient4Config;
-import io.dropwizard.client.HttpClientBuilder;
-import io.dropwizard.client.HttpClientConfiguration;
-import io.dropwizard.jackson.Jackson;
-import io.dropwizard.jersey.jackson.JacksonMessageBodyProvider;
-import org.apache.http.client.HttpClient;
+import io.dropwizard.client.JerseyClientBuilder;
+import io.dropwizard.client.JerseyClientConfiguration;
 
-import javax.validation.Validation;
-import javax.validation.Validator;
+import javax.ws.rs.ProcessingException;
+import javax.ws.rs.ServerErrorException;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.core.Response;
 import java.net.URI;
 
 public class CalculatorServiceFactory implements ServiceFactory<CalculatorService> {
@@ -27,7 +19,7 @@ public class CalculatorServiceFactory implements ServiceFactory<CalculatorServic
     /**
      * Connects to the CalculatorService using the Apache commons http client library.
      */
-    public CalculatorServiceFactory(HttpClientConfiguration configuration, MetricRegistry metrics) {
+    public CalculatorServiceFactory(JerseyClientConfiguration configuration, MetricRegistry metrics) {
         this(createDefaultJerseyClient(configuration, metrics));
     }
 
@@ -39,14 +31,9 @@ public class CalculatorServiceFactory implements ServiceFactory<CalculatorServic
         _client = jerseyClient;
     }
 
-    private static ApacheHttpClient4 createDefaultJerseyClient(HttpClientConfiguration configuration,
+    private static Client createDefaultJerseyClient(JerseyClientConfiguration configuration,
                                                                MetricRegistry metrics) {
-        HttpClient httpClient = new HttpClientBuilder(metrics).using(configuration).build("calculator");
-        ApacheHttpClient4Handler handler = new ApacheHttpClient4Handler(httpClient, null, true);
-        ApacheHttpClient4Config config = new DefaultApacheHttpClient4Config();
-        Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
-        config.getSingletons().add(new JacksonMessageBodyProvider(Jackson.newObjectMapper(), validator));
-        return new ApacheHttpClient4(handler, config);
+        return new JerseyClientBuilder(metrics).using(configuration).build("calculator");
     }
 
     @Override
@@ -71,15 +58,17 @@ public class CalculatorServiceFactory implements ServiceFactory<CalculatorServic
 
     @Override
     public boolean isRetriableException(Exception exception) {
-        // Try another server if network error (ClientHandlerException) or 5xx response code (UniformInterfaceException)
-        return exception instanceof ClientHandlerException ||
-                (exception instanceof UniformInterfaceException &&
-                        ((UniformInterfaceException) exception).getResponse().getStatus() >= 500);
+        // Try another server if network error or parsing error (ProcessingException)
+        // or 5xx response code (ServerErrorException)
+        return exception instanceof ProcessingException || exception instanceof ServerErrorException;
     }
 
     @Override
     public boolean isHealthy(ServiceEndPoint endPoint) {
         URI adminUrl = Payload.valueOf(endPoint.getPayload()).getAdminUrl();
-        return _client.resource(adminUrl).path("/healthcheck").head().getStatus() == 200;
+        Response response = _client.target(adminUrl).path("/healthcheck").request().method("HEAD");
+        int status = response.getStatus();
+        response.close();
+        return status == 200;
     }
 }

--- a/examples/dictionary/client/src/main/java/com/bazaarvoice/ostrich/examples/dictionary/client/DictionaryServiceFactory.java
+++ b/examples/dictionary/client/src/main/java/com/bazaarvoice/ostrich/examples/dictionary/client/DictionaryServiceFactory.java
@@ -4,21 +4,13 @@ import com.bazaarvoice.ostrich.ServiceEndPoint;
 import com.bazaarvoice.ostrich.ServiceFactory;
 import com.bazaarvoice.ostrich.pool.ServicePoolBuilder;
 import com.codahale.metrics.MetricRegistry;
-import com.sun.jersey.api.client.Client;
-import com.sun.jersey.api.client.ClientHandlerException;
-import com.sun.jersey.api.client.UniformInterfaceException;
-import com.sun.jersey.client.apache4.ApacheHttpClient4;
-import com.sun.jersey.client.apache4.ApacheHttpClient4Handler;
-import com.sun.jersey.client.apache4.config.ApacheHttpClient4Config;
-import com.sun.jersey.client.apache4.config.DefaultApacheHttpClient4Config;
-import io.dropwizard.client.HttpClientBuilder;
-import io.dropwizard.client.HttpClientConfiguration;
-import io.dropwizard.jackson.Jackson;
-import io.dropwizard.jersey.jackson.JacksonMessageBodyProvider;
-import org.apache.http.client.HttpClient;
+import io.dropwizard.client.JerseyClientBuilder;
+import io.dropwizard.client.JerseyClientConfiguration;
 
-import javax.validation.Validation;
-import javax.validation.Validator;
+import javax.ws.rs.ProcessingException;
+import javax.ws.rs.ServerErrorException;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.core.Response;
 import java.net.URI;
 
 public class DictionaryServiceFactory implements ServiceFactory<DictionaryService> {
@@ -27,7 +19,7 @@ public class DictionaryServiceFactory implements ServiceFactory<DictionaryServic
     /**
      * Connects to the DictionaryService using the Apache commons http client library.
      */
-    public DictionaryServiceFactory(HttpClientConfiguration configuration, MetricRegistry metrics) {
+    public DictionaryServiceFactory(JerseyClientConfiguration configuration, MetricRegistry metrics) {
         this(createDefaultJerseyClient(configuration, metrics));
     }
 
@@ -39,14 +31,9 @@ public class DictionaryServiceFactory implements ServiceFactory<DictionaryServic
         _client = jerseyClient;
     }
 
-    private static ApacheHttpClient4 createDefaultJerseyClient(HttpClientConfiguration configuration,
+    private static Client createDefaultJerseyClient(JerseyClientConfiguration configuration,
                                                                MetricRegistry metrics) {
-        HttpClient httpClient = new HttpClientBuilder(metrics).using(configuration).build("dictionary");
-        ApacheHttpClient4Handler handler = new ApacheHttpClient4Handler(httpClient, null, true);
-        ApacheHttpClient4Config config = new DefaultApacheHttpClient4Config();
-        Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
-        config.getSingletons().add(new JacksonMessageBodyProvider(Jackson.newObjectMapper(), validator));
-        return new ApacheHttpClient4(handler, config);
+        return new JerseyClientBuilder(metrics).using(configuration).build("dictionary");
     }
 
     @Override
@@ -73,15 +60,17 @@ public class DictionaryServiceFactory implements ServiceFactory<DictionaryServic
 
     @Override
     public boolean isRetriableException(Exception exception) {
-        // Try another server if network error (ClientHandlerException) or 5xx response code (UniformInterfaceException)
-        return exception instanceof ClientHandlerException ||
-                (exception instanceof UniformInterfaceException &&
-                        ((UniformInterfaceException) exception).getResponse().getStatus() >= 500);
+        // Try another server if network error or parsing error (ProcessingException)
+        // or 5xx response code (ServerErrorException)
+        return exception instanceof ProcessingException || exception instanceof ServerErrorException;
     }
 
     @Override
     public boolean isHealthy(ServiceEndPoint endPoint) {
         URI adminUrl = Payload.valueOf(endPoint.getPayload()).getAdminUrl();
-        return _client.resource(adminUrl).path("/healthcheck").head().getStatus() == 200;
+        Response response = _client.target(adminUrl).path("/healthcheck").request().method("HEAD");
+        int status = response.getStatus();
+        response.close();
+        return status == 200;
     }
 }

--- a/examples/dictionary/client/src/main/java/com/bazaarvoice/ostrich/examples/dictionary/client/DictionaryServiceFactory.java
+++ b/examples/dictionary/client/src/main/java/com/bazaarvoice/ostrich/examples/dictionary/client/DictionaryServiceFactory.java
@@ -71,6 +71,6 @@ public class DictionaryServiceFactory implements ServiceFactory<DictionaryServic
         Response response = _client.target(adminUrl).path("/healthcheck").request().method("HEAD");
         int status = response.getStatus();
         response.close();
-        return status == 200;
+        return status == Response.Status.OK.getStatusCode();
     }
 }

--- a/owasp-suppression.xml
+++ b/owasp-suppression.xml
@@ -6,14 +6,8 @@
 >
     <suppress>
         <notes><![CDATA[
-   file name: jackson-datatype-jdk7-2.6.7.jar
-   ]]></notes>
-        <cve>CVE-2016-7051</cve>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[
-   file name: jackson-datatype-jdk7-2.6.7.jar
-   ]]></notes>
-        <cve>CVE-2016-3720</cve>
+    file name: curator-framework-2.12.0.jar
+    ]]></notes>
+        <cve>CVE-2016-5017</cve>
     </suppress>
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -30,11 +30,12 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.minimum.version>1.7</java.minimum.version>
-        <curator.extensions.version>1.5.1</curator.extensions.version>
-        <dropwizard.version>0.7.1</dropwizard.version>
-        <slf4j.version>1.7.21</slf4j.version>
+        <curator.extensions.version>1.5.2</curator.extensions.version>
+        <dropwizard.version>[0.8.0,0.9.3]</dropwizard.version>
+        <slf4j.version>1.7.25</slf4j.version>
         <logback.version>1.2.3</logback.version>
-        <jackson.version>2.9.4</jackson.version>
+        <jackson.version>2.9.6</jackson.version>
+        <jetty.version>9.4.12.v20180830</jetty.version>
     </properties>
 
     <build>
@@ -42,7 +43,7 @@
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.2</version>
+                <version>1.6.8</version>
                 <extensions>true</extensions>
                 <configuration>
                     <serverId>sonatype-nexus-staging</serverId>
@@ -53,6 +54,7 @@
             <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
+                <version>3.3.1</version>
                 <configuration>
                     <failBuildOnCVSS>6</failBuildOnCVSS>
                     <suppressionFile>
@@ -75,8 +77,10 @@
                 <!-- Make sure we always turn all warnings on during compilation. -->
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.7.0</version>
+                    <version>3.8.0</version>
                     <configuration>
+                        <source>1.7</source>
+                        <target>1.7</target>
                         <compilerArgument>-Xlint:all</compilerArgument>
                         <showWarnings>true</showWarnings>
                         <showDeprecation>true</showDeprecation>
@@ -157,6 +161,54 @@
             </dependency>
 
             <dependency>
+                <groupId>io.dropwizard</groupId>
+                <artifactId>dropwizard-core</artifactId>
+                <version>${dropwizard.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-util</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-http</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-server</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-webapp</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-servlet</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-servlets</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-continuation</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>4.12</version>
@@ -166,7 +218,7 @@
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
-                <version>1.9.5</version>
+                <version>2.21.0</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>


### PR DESCRIPTION
This makes the examples depend on Dropwizard 0.8+ and Jersey 2+, but the library itself can run with any version. Made the Dropwizard dependency a range to reflect that, but could alternatively specify different versions for examples than for the dropwizard module.