### PR TITLE
Make compatible with current Guava

### DIFF
--- a/core/src/main/java/com/bazaarvoice/ostrich/ServiceEndPointBuilder.java
+++ b/core/src/main/java/com/bazaarvoice/ostrich/ServiceEndPointBuilder.java
@@ -5,6 +5,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 
 import java.util.Objects;
+import java.util.StringJoiner;
 
 public class ServiceEndPointBuilder {
     // Service names and versions have a restricted set of valid characters in them for simplicity.  These are the
@@ -87,10 +88,10 @@ public class ServiceEndPointBuilder {
 
             @Override
             public String toString() {
-                return com.google.common.base.Objects.toStringHelper("ServiceEndPoint")
-                        .add("name", serviceName)
-                        .add("id", id)
-                        .add("payload", payload)
+                return new StringJoiner(", ", ServiceEndPoint.class.getSimpleName() + "{", "}")
+                        .add("name=" + _serviceName)
+                        .add("id=" + _id)
+                        .add("payload=" + _payload)
                         .toString();
             }
         };

--- a/core/src/main/java/com/bazaarvoice/ostrich/pool/AnnotationPartitionContextSupplier.java
+++ b/core/src/main/java/com/bazaarvoice/ostrich/pool/AnnotationPartitionContextSupplier.java
@@ -3,7 +3,6 @@ package com.bazaarvoice.ostrich.pool;
 import com.bazaarvoice.ostrich.PartitionContext;
 import com.bazaarvoice.ostrich.PartitionContextBuilder;
 import com.bazaarvoice.ostrich.partition.PartitionKey;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 
@@ -45,7 +44,7 @@ class AnnotationPartitionContextSupplier implements PartitionContextSupplier {
             try {
                 implMethod = impl.getMethod(ifcMethod.getName(), ifcMethod.getParameterTypes());
             } catch (NoSuchMethodException e) {
-                throw Throwables.propagate(e);  // Should never happen if impl implements ifc.
+                throw new RuntimeException(e);  // Should never happen if impl implements ifc.
             }
 
             String[] keyMappings = collectPartitionKeyAnnotations(implMethod);

--- a/core/src/main/java/com/bazaarvoice/ostrich/pool/MultiThreadedClientServiceCache.java
+++ b/core/src/main/java/com/bazaarvoice/ostrich/pool/MultiThreadedClientServiceCache.java
@@ -300,7 +300,7 @@ public class MultiThreadedClientServiceCache<S> implements ServiceCache<S> {
 
         // This method is synchronized, as even though we are not swapping the copy-on-write map,
         // we are still modifying its contents a bit.
-        HeavyServiceHandle serviceHandle = _instancesPerEndpoint.get(endPoint);
+        HeavyServiceHandle<?> serviceHandle = _instancesPerEndpoint.get(endPoint);
         if (serviceHandle != null) {
             serviceHandle.flagAsEvicted();
         }

--- a/core/src/main/java/com/bazaarvoice/ostrich/pool/ServicePool.java
+++ b/core/src/main/java/com/bazaarvoice/ostrich/pool/ServicePool.java
@@ -25,7 +25,6 @@ import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Objects;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 import com.google.common.base.Throwables;
@@ -40,6 +39,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Set;
+import java.util.StringJoiner;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
@@ -620,8 +620,8 @@ class ServicePool<S> implements com.bazaarvoice.ostrich.ServicePool<S> {
 
         @Override
         public String toString() {
-            return Objects.toStringHelper(this)
-                    .add("endPointId", _endPointId)
+            return new StringJoiner(", ", SuccessfulHealthCheckResult.class.getSimpleName() + "{", "}")
+                    .add("endPointId=" + _endPointId)
                     .toString();
         }
     }
@@ -662,9 +662,9 @@ class ServicePool<S> implements com.bazaarvoice.ostrich.ServicePool<S> {
 
         @Override
         public String toString() {
-            return Objects.toStringHelper(this)
-                    .add("endPointId", _endPointId)
-                    .add("exception", _exception)
+            return new StringJoiner(", ", FailedHealthCheckResult.class.getSimpleName() + "{", "}")
+                    .add("endPointId=" + _endPointId)
+                    .add("exception=" + _exception)
                     .toString();
         }
     }

--- a/core/src/main/java/com/bazaarvoice/ostrich/pool/ServicePoolBuilder.java
+++ b/core/src/main/java/com/bazaarvoice/ostrich/pool/ServicePoolBuilder.java
@@ -336,7 +336,8 @@ public class ServicePoolBuilder<S> {
                 _closeHostDiscovery = false;
             }
 
-            throw Throwables.propagate(t);
+            Throwables.throwIfUnchecked(t);
+            throw new RuntimeException(t);
         }
     }
 

--- a/core/src/main/java/com/bazaarvoice/ostrich/pool/ServicePoolProxy.java
+++ b/core/src/main/java/com/bazaarvoice/ostrich/pool/ServicePoolProxy.java
@@ -70,9 +70,10 @@ class ServicePoolProxy<S> extends AbstractInvocationHandler {
                 try {
                     return method.invoke(service, args);
                 } catch (IllegalAccessException e) {
-                    throw Throwables.propagate(e);
+                    throw new RuntimeException(e);
                 } catch (InvocationTargetException e) {
-                    throw Throwables.propagate(e.getTargetException());
+                    Throwables.throwIfUnchecked(e.getTargetException());
+                    throw new RuntimeException(e.getTargetException());
                 }
             }
         });

--- a/core/src/test/java/com/bazaarvoice/ostrich/pool/AsyncServicePoolTest.java
+++ b/core/src/test/java/com/bazaarvoice/ostrich/pool/AsyncServicePoolTest.java
@@ -94,7 +94,7 @@ public class AsyncServicePoolTest {
     @Test
     public void testExecutesCallbackInPool() {
         // Use a real executor so that it can actually call into the callback
-        AsyncServicePool<Service> pool = newAsyncPool(MoreExecutors.sameThreadExecutor());
+        AsyncServicePool<Service> pool = newAsyncPool(MoreExecutors.newDirectExecutorService());
 
         ServiceCallback<Service, Void> callback = (ServiceCallback<Service, Void>) mock(ServiceCallback.class);
         pool.execute(NEVER_RETRY, callback);
@@ -105,7 +105,7 @@ public class AsyncServicePoolTest {
     @SuppressWarnings("unchecked")
     @Test
     public void testExecutesPartitionContextInPool() {
-        AsyncServicePool<Service> pool = newAsyncPool(MoreExecutors.sameThreadExecutor());
+        AsyncServicePool<Service> pool = newAsyncPool(MoreExecutors.newDirectExecutorService());
 
         ServiceCallback<Service, Void> callback = (ServiceCallback<Service, Void>) mock(ServiceCallback.class);
         PartitionContext context = mock(PartitionContext.class);
@@ -139,7 +139,7 @@ public class AsyncServicePoolTest {
         when(_mockPool.getAllEndPoints()).thenReturn(Lists.newArrayList(FOO, BAR, BAZ));
 
         // Use a real executor so that it can actually call into the callback
-        AsyncServicePool<Service> pool = newAsyncPool(MoreExecutors.sameThreadExecutor());
+        AsyncServicePool<Service> pool = newAsyncPool(MoreExecutors.newDirectExecutorService());
 
         ServiceCallback<Service, Void> callback = (ServiceCallback<Service, Void>) mock(ServiceCallback.class);
         pool.executeOnAll(NEVER_RETRY, callback);
@@ -162,7 +162,7 @@ public class AsyncServicePoolTest {
         when(_mockPool.executeOnEndPoint(same(BAZ), any(ServiceCallback.class))).thenReturn("BAZ");
 
         // Use a real executor so that it can actually call into the callback
-        AsyncServicePool<Service> pool = newAsyncPool(MoreExecutors.sameThreadExecutor());
+        AsyncServicePool<Service> pool = newAsyncPool(MoreExecutors.newDirectExecutorService());
 
         Collection<Future<String>> futures = pool.executeOnAll(NEVER_RETRY, mock(ServiceCallback.class));
         assertEquals(3, futures.size());
@@ -183,7 +183,7 @@ public class AsyncServicePoolTest {
         when(_mockPool.isRetriableException(any(Exception.class))).thenReturn(false);
 
         // Use a real executor so that it can actually call into the callback
-        AsyncServicePool<Service> pool = newAsyncPool(MoreExecutors.sameThreadExecutor());
+        AsyncServicePool<Service> pool = newAsyncPool(MoreExecutors.newDirectExecutorService());
 
         Collection<Future<Void>> futures = pool.executeOnAll(NEVER_RETRY, mock(ServiceCallback.class));
         assertEquals(1, futures.size());
@@ -206,7 +206,7 @@ public class AsyncServicePoolTest {
         when(_mockPool.isRetriableException(any(Exception.class))).thenReturn(true);
 
         // Use a real executor so that it can actually call into the callback
-        AsyncServicePool<Service> pool = newAsyncPool(MoreExecutors.sameThreadExecutor());
+        AsyncServicePool<Service> pool = newAsyncPool(MoreExecutors.newDirectExecutorService());
 
         Collection<Future<Void>> futures = pool.executeOnAll(NEVER_RETRY, mock(ServiceCallback.class));
         assertEquals(1, futures.size());
@@ -276,7 +276,7 @@ public class AsyncServicePoolTest {
         when(predicate.apply(same(BAZ))).thenReturn(true);
 
         // Use a real executor so that it can actually call into the callback
-        AsyncServicePool<Service> pool = newAsyncPool(MoreExecutors.sameThreadExecutor());
+        AsyncServicePool<Service> pool = newAsyncPool(MoreExecutors.newDirectExecutorService());
 
         ServiceCallback<Service, Void> callback = (ServiceCallback<Service, Void>) mock(ServiceCallback.class);
         pool.executeOn(predicate, NEVER_RETRY, callback);
@@ -300,7 +300,7 @@ public class AsyncServicePoolTest {
         when(predicate.apply(same(BAZ))).thenReturn(false);
 
         // Use a real executor so that it can actually call into the callback
-        AsyncServicePool<Service> pool = newAsyncPool(MoreExecutors.sameThreadExecutor());
+        AsyncServicePool<Service> pool = newAsyncPool(MoreExecutors.newDirectExecutorService());
         pool.executeOn(predicate, NEVER_RETRY, mock(ServiceCallback.class));
 
         verify(_mockPool, never()).executeOnEndPoint(any(ServiceEndPoint.class), any(ServiceCallback.class));
@@ -319,7 +319,7 @@ public class AsyncServicePoolTest {
         when(_mockPool.executeOnEndPoint(same(BAZ), any(ServiceCallback.class))).thenReturn("BAZ");
 
         // Use a real executor so that it can actually call into the callback
-        AsyncServicePool<Service> pool = newAsyncPool(MoreExecutors.sameThreadExecutor());
+        AsyncServicePool<Service> pool = newAsyncPool(MoreExecutors.newDirectExecutorService());
 
         ServiceEndPointPredicate predicate = mock(ServiceEndPointPredicate.class);
         when(predicate.apply(same(FOO))).thenReturn(false);
@@ -342,7 +342,7 @@ public class AsyncServicePoolTest {
         when(predicate.apply(any(ServiceEndPoint.class))).thenReturn(true);
 
         // Use a real executor so that it can actually call into the callback
-        AsyncServicePool<Service> pool = newAsyncPool(MoreExecutors.sameThreadExecutor());
+        AsyncServicePool<Service> pool = newAsyncPool(MoreExecutors.newDirectExecutorService());
 
         pool.executeOn(predicate, NEVER_RETRY, mock(ServiceCallback.class));
 
@@ -362,7 +362,7 @@ public class AsyncServicePoolTest {
         when(_mockPool.isRetriableException(any(Exception.class))).thenReturn(true);
 
         // Use a real executor so that it can actually call into the callback
-        AsyncServicePool<Service> pool = newAsyncPool(MoreExecutors.sameThreadExecutor());
+        AsyncServicePool<Service> pool = newAsyncPool(MoreExecutors.newDirectExecutorService());
 
         RetryPolicy retry = mock(RetryPolicy.class);
         when(retry.allowRetry(anyInt(), anyLong())).thenReturn(true);

--- a/core/src/test/java/com/bazaarvoice/ostrich/pool/ServicePoolCachingTest.java
+++ b/core/src/test/java/com/bazaarvoice/ostrich/pool/ServicePoolCachingTest.java
@@ -13,7 +13,6 @@ import com.bazaarvoice.ostrich.exceptions.ServiceException;
 import com.bazaarvoice.ostrich.healthcheck.FixedHealthCheckRetryDelay;
 import com.bazaarvoice.ostrich.partition.PartitionFilter;
 import com.codahale.metrics.MetricRegistry;
-import com.google.common.base.Throwables;
 import com.google.common.base.Ticker;
 import com.google.common.collect.ImmutableList;
 import org.junit.After;
@@ -217,7 +216,7 @@ public class ServicePoolCachingTest {
                             try {
                                 canReturn.await(10, TimeUnit.SECONDS);
                             } catch (InterruptedException e) {
-                                throw Throwables.propagate(e);
+                                throw new RuntimeException(e);
                             }
 
                             return service;
@@ -276,7 +275,7 @@ public class ServicePoolCachingTest {
                             try {
                                 canReturn.await(10, TimeUnit.SECONDS);
                             } catch (InterruptedException e) {
-                                throw Throwables.propagate(e);
+                                throw new RuntimeException(e);
                             }
 
                             return service;

--- a/examples/dictionary/service/src/main/java/com/bazaarvoice/ostrich/examples/dictionary/service/IllegalArgumentExceptionMapper.java
+++ b/examples/dictionary/service/src/main/java/com/bazaarvoice/ostrich/examples/dictionary/service/IllegalArgumentExceptionMapper.java
@@ -1,10 +1,9 @@
 package com.bazaarvoice.ostrich.examples.dictionary.service;
 
-import com.google.common.base.Objects;
-
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
+import java.util.Optional;
 
 @Provider
 public class IllegalArgumentExceptionMapper implements ExceptionMapper<IllegalArgumentException> {
@@ -12,7 +11,7 @@ public class IllegalArgumentExceptionMapper implements ExceptionMapper<IllegalAr
     public Response toResponse(IllegalArgumentException e) {
         return Response.status(Response.Status.BAD_REQUEST)
                 .header("X-BV-Exception", e.getClass().getName())
-                .entity(Objects.firstNonNull(e.getMessage(), "Invalid argument."))
+                .entity(Optional.ofNullable(e.getMessage()).orElse("Invalid argument."))
                 .build();
     }
 }

--- a/examples/dictionary/service/src/main/java/com/bazaarvoice/ostrich/examples/dictionary/service/WordList.java
+++ b/examples/dictionary/service/src/main/java/com/bazaarvoice/ostrich/examples/dictionary/service/WordList.java
@@ -15,7 +15,7 @@ public class WordList implements Predicate<String> {
 
     public WordList(File file, final Predicate<String> filter) throws IOException {
         words = Sets.newHashSet();
-        Files.readLines(file, Charsets.UTF_8, new LineProcessor<Void>() {
+        Files.asCharSource(file, Charsets.UTF_8).readLines(new LineProcessor<Void>() {
             @Override
             public boolean processLine(String line) throws IOException {
                 if (filter.apply(line)) {

--- a/examples/dictionary/user/src/main/java/com/bazaarvoice/ostrich/examples/dictionary/user/DictionaryUser.java
+++ b/examples/dictionary/user/src/main/java/com/bazaarvoice/ostrich/examples/dictionary/user/DictionaryUser.java
@@ -50,10 +50,10 @@ public class DictionaryUser {
 
     public void spellCheck(File file) throws IOException {
         LOG.info("Spell checking file: {}", file);
-        Files.readLines(file, Charsets.UTF_8, new LineProcessor<Void>() {
+        Files.asCharSource(file, Charsets.UTF_8).readLines(new LineProcessor<Void>() {
             @Override
             public boolean processLine(String line) throws IOException {
-                for (String word : Splitter.on(CharMatcher.WHITESPACE).split(line)) {
+                for (String word : Splitter.on(CharMatcher.whitespace()).split(line)) {
                     // Discard punctuation, numbers, etc.
                     word = LETTER.retainFrom(word);
                     if (!word.isEmpty()) {

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>20.0</version>
+                <version>24.1.1-jre</version>
             </dependency>
 
             <dependency>

--- a/zookeeper/discovery/src/main/java/com/bazaarvoice/ostrich/discovery/zookeeper/ZooKeeperHostDiscovery.java
+++ b/zookeeper/discovery/src/main/java/com/bazaarvoice/ostrich/discovery/zookeeper/ZooKeeperHostDiscovery.java
@@ -15,13 +15,13 @@ import com.google.common.collect.ConcurrentHashMultiset;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multiset;
-import com.google.common.collect.Sets;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.utils.ZKPaths;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -69,7 +69,7 @@ public class ZooKeeperHostDiscovery implements HostDiscovery {
 
         String servicePath = makeServicePath(serviceName);
 
-        _listeners = Sets.newSetFromMap(Maps.<EndPointListener, Boolean>newConcurrentMap());
+        _listeners = Collections.newSetFromMap(Maps.newConcurrentMap());
         _endPoints = ConcurrentHashMultiset.create();
 
         _nodeDiscovery = factory.create(


### PR DESCRIPTION
* This PR removes Guava usages that are no longer supported in the current version (``27.1``), which fixed #195.
* This also replaces all usages of deprecated methods, with the lone exception of ``com.google.common.hash.Hashing.md5()`` in ``ConsistentHashPartitionFilter``.  I've left this because there is no simple replacement, and it is unclear to me whether changing the hashing algorithm could substantially impact the behavior of the filter.

All usages are replaced with either Java 8 equivalents, or with an alternative method that is supported by Guava 19+, which is the current minimum version, due to preexisting usages of ``com.google.common.base.CharMatcher.none()`` (and possibly other APIs).  Therefore, this change should be compatible with all usages of the current ``2.0.1`` version, and is therefore a patch release.

I've gone ahead and upgrade the Guava dependency itself to 24.1.1, since previous versions of Guava are vulnerable to https://nvd.nist.gov/vuln/detail/CVE-2018-10237.

As an aside, it's worth noting that this library does depend on ``com.bazaarvoice.curator:recipes``; however, it does not utilize the ``LeaderService`` and is therefore unaffected by https://github.com/bazaarvoice/curator-extensions/issues/43.  AFAICT no other runtime depenencies have Guava compatibility issues, at least thru ``24.1.1``.